### PR TITLE
adaptix v1.0 comp.

### DIFF
--- a/agent_kharon/pl_agent.go
+++ b/agent_kharon/pl_agent.go
@@ -2517,7 +2517,7 @@ func ProcessTasksResult(ts Teamserver, agentData adaptix.AgentData, taskData ada
 							task.MessageType = MESSAGE_ERROR
 							fmt.Printf("Deleting fileID: %d\n", file_id)
 
-							_ = ts.TsDownloadDelete(file_id)
+							_ = ts.TsDownloadDelete([]string{file_id})
 							continue
 						}
 


### PR DESCRIPTION
fix: update TsDownloadDelete for Adaptix Framework v1.0 compatibility

- Updated TsDownloadDelete signature from string to []string (v1.0 requirement)
- Fixed TsDownloadDelete usage to pass slice {file_id} instead of string
- Fixes download failure handling and prevents server crashes

This resolves the critical ExtAgent interface error and allows Kharon agents to function properly with Adaptix Framework v1.0.

Related: https://adaptix-framework.gitbook.io/adaptix-framework/changelog-and-updates/version-1.0