### PR TITLE
x-forwarded-host support

### DIFF
--- a/listener_kharon_http/dist/ax_config.axs
+++ b/listener_kharon_http/dist/ax_config.axs
@@ -15,6 +15,13 @@ function ListenerUI(mode_create)
     spinPortBind.setValue(443);
     spinPortBind.setEnabled(mode_create);
 
+    // === TRUSTED HOST HEADERS ===
+    let checkTrustXForwardedHost = form.create_check("Trust X-Forwarded-Host");
+
+    let labelAdditionalTrustedHosts = form.create_label("Additional Trusted Hosts:");
+    let textAdditionalTrustedHosts = form.create_textmulti();
+    textAdditionalTrustedHosts.setPlaceholder("domain1.com\ndomain2.com");
+
     // === BLOCK USER AGENTS ===
     let labelBlockUserAgents = form.create_label("Block User Agents:");
     let blockUserAgentsText = form.create_textmulti();
@@ -99,18 +106,23 @@ function ListenerUI(mode_create)
     layoutMain.addWidget(comboHostBind, 0, 1, 1, 1);
     layoutMain.addWidget(spinPortBind,  0, 2, 1, 1);
 
-    layoutMain.addWidget(labelBlockUserAgents, 1, 0, 1, 3);
-    layoutMain.addWidget(blockUserAgentsText,  2, 0, 1, 3);
+    // Trusted Host Headers
+    layoutMain.addWidget(checkTrustXForwardedHost, 1, 0, 1, 3);
+    layoutMain.addWidget(labelAdditionalTrustedHosts, 2, 0, 1, 3);
+    layoutMain.addWidget(textAdditionalTrustedHosts, 3, 0, 1, 3);
 
-    layoutMain.addWidget(labelDomainRotation, 3, 0, 1, 1);
-    layoutMain.addWidget(domainRotationCombo, 3, 1, 1, 2);
+    layoutMain.addWidget(labelBlockUserAgents, 4, 0, 1, 3);
+    layoutMain.addWidget(blockUserAgentsText,  5, 0, 1, 3);
 
-    layoutMain.addWidget(labelUploadProfile,  4, 0, 1, 1);
-    layoutMain.addWidget(fileSelector,        4, 1, 1, 2);
+    layoutMain.addWidget(labelDomainRotation, 6, 0, 1, 1);
+    layoutMain.addWidget(domainRotationCombo, 6, 1, 1, 2);
+
+    layoutMain.addWidget(labelUploadProfile,  7, 0, 1, 1);
+    layoutMain.addWidget(fileSelector,        7, 1, 1, 2);
     // layoutMain.addWidget(uploadedFileText,    5, 0, 1, 3);
 
-    layoutMain.addWidget(proxy_group,        5, 0, 1, 3);
-    layoutMain.addWidget(ssl_group,          6, 0, 1, 3);
+    layoutMain.addWidget(proxy_group,         8, 0, 1, 3);
+    layoutMain.addWidget(ssl_group,            9, 0, 1, 3);
 
     let panelMain = form.create_panel();
     panelMain.setLayout(layoutMain);
@@ -140,6 +152,10 @@ function ListenerUI(mode_create)
     container.put("ssl", ssl_group);
     container.put("ssl_cert", certSelector);
     container.put("ssl_key", keySelector);
+
+    // Trusted Host Headers
+    container.put("trust_x_forwarded_host", checkTrustXForwardedHost);
+    container.put("additional_trusted_hosts", textAdditionalTrustedHosts);
 
     let layout = form.create_hlayout();
     layout.addWidget(panelMain);

--- a/listener_kharon_http/src_server/pl_http.go
+++ b/listener_kharon_http/src_server/pl_http.go
@@ -587,7 +587,54 @@ func (handler *HTTP) process_request(ctx *gin.Context) {
 
 	fmt.Printf("[DEBUG] Incoming request - URI: %s, Method: %s, UA: %s\n", client.Uri, client.HttpMethod, client.UserAgent)
 
-	callbackByHost = handler.get_callback_by_host(client.Address)
+	// Check if we should trust X-Forwarded-Host header and skip callback matching
+	skipHostMatching := false
+
+	if handler.Config.TrustXForwardedHost {
+		xForwardedHost := ctx.GetHeader("X-Forwarded-Host")
+		if xForwardedHost != "" {
+			// Strip port if present
+			if idx := strings.LastIndex(xForwardedHost, ":"); idx != -1 {
+				xForwardedHost = xForwardedHost[:idx]
+			}
+			fmt.Printf("[DEBUG] Trusting X-Forwarded-Host: %s\n", xForwardedHost)
+			client.Address = xForwardedHost
+			skipHostMatching = true
+		}
+	}
+
+	// Check if host matches additional trusted hosts list
+	if !skipHostMatching && handler.Config.AdditionalTrustedHosts != "" {
+		trustedHosts := strings.Split(handler.Config.AdditionalTrustedHosts, "\n")
+		for _, trustedHost := range trustedHosts {
+			trustedHost = strings.TrimSpace(trustedHost)
+			if trustedHost == "" {
+				continue
+			}
+			if strings.EqualFold(trustedHost, client.Address) {
+				fmt.Printf("[DEBUG] Host matches additional trusted host: %s\n", client.Address)
+				skipHostMatching = true
+				break
+			}
+		}
+	}
+
+	if skipHostMatching {
+		// Trust the host, use the first callback
+		if len(handler.Config.Callbacks) > 0 {
+			callbackByHost = &handler.Config.Callbacks[0]
+			fmt.Printf("[DEBUG] Using first callback (trusted host)\n")
+		} else {
+			fmt.Printf("[ERROR] No callbacks configured\n")
+			ctx.Writer.Write([]byte("Bad Request"))
+			ctx.Status(http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Normal callback host matching
+		callbackByHost = handler.get_callback_by_host(client.Address)
+	}
+
 	if callbackByHost == nil {
 		fmt.Printf("[ERROR] No callback found for host: %s\n", client.Address)
 		ctx.Writer.Write([]byte("Bad Request"))

--- a/listener_kharon_http/src_server/pl_structs.go
+++ b/listener_kharon_http/src_server/pl_structs.go
@@ -84,6 +84,9 @@ type HTTPConfig struct {
 	ProxyUserName string `json:"proxy_user"`
 	ProxyPassword string `json:"proxy_pass"`
 
+	TrustXForwardedHost    bool   `json:"trust_x_forwarded_host"`
+	AdditionalTrustedHosts string `json:"additional_trusted_hosts"`
+
 	ChunkTask []HttpTask
 
 	Addresses 	string


### PR DESCRIPTION
This will add a checkbox to trust any x-forwarded-host or use custom hostnames to trust and accept connections from. 