### PR TITLE
fix: normalize host:port matching in callback lookup

### DIFF
--- a/listener_kharon_http/src_server/pl_utils.go
+++ b/listener_kharon_http/src_server/pl_utils.go
@@ -133,6 +133,13 @@ func (handler *HTTP) get_all_uris(method *HTTPMethod) []string {
 	return uris
 }
 
+func stripPort(hostport string) string {
+	if idx := strings.LastIndex(hostport, ":"); idx != -1 {
+		return hostport[:idx]
+	}
+	return hostport
+}
+
 func (handler *HTTP) get_callback_by_host(host string) *Callback {
 	if host == "" {
 		return nil
@@ -141,18 +148,21 @@ func (handler *HTTP) get_callback_by_host(host string) *Callback {
 	fmt.Printf("[DEBUG] Looking for callback with address: %s\n", host)
 	fmt.Printf("[DEBUG] Total callbacks available: %d\n", len(handler.Config.Callbacks))
 
+	hostNoPort := stripPort(host)
+
 	for i := range handler.Config.Callbacks {
 		callback := handler.Config.Callbacks[i]
 		fmt.Printf("[DEBUG] Checking callback %d with %d hosts\n", i, len(callback.Hosts))
 
 		for j, callbackHost := range callback.Hosts {
-			fmt.Printf("[DEBUG][%d][%d] Comparing: '%s' == '%s'? %v\n",
-				i, j, callbackHost, host, strings.EqualFold(callbackHost, host))
+			callbackHostNoPort := stripPort(callbackHost)
 
-			if strings.EqualFold(callbackHost, host) {
-				fmt.Printf("[SUCCESS] Found callback at index %d for host: %s\n", i, host)
+			if strings.EqualFold(callbackHost, host) || strings.EqualFold(callbackHostNoPort, host) || strings.EqualFold(callbackHost, hostNoPort) || strings.EqualFold(callbackHostNoPort, hostNoPort) {
+				fmt.Printf("[SUCCESS] Found callback at index %d for host: %s (matched with %s)\n", i, host, callbackHost)
 				return &callback
 			}
+
+			fmt.Printf("[DEBUG][%d][%d] Comparing: '%s' == '%s'? false\n", i, j, callbackHost, host)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix `get_callback_by_host` failing to match callbacks when the HTTP `Host` header omits standard ports (443/HTTPS, 80/HTTP)
- Per RFC 2616, browsers and HTTP clients omit standard ports from the `Host` header, but profile hosts are typically defined with ports (e.g. `"192.168.1.70:443"`)
- The comparison `"192.168.1.70:443" == "192.168.1.70"` always failed, causing all incoming requests to be rejected

## Changes

Normalize both the incoming host and callback host by stripping the port before comparing, so that `192.168.1.70:443` correctly matches `192.168.1.70`.

## Test plan

- [x] Create an HTTPS listener on port 443 with a profile containing `"hosts": ["<ip>:443"]`
- [x] Verify the agent connects successfully (previously failed with `No callback found for address`)
- [x] Non-standard ports (e.g. 8443) still work as expected since the client includes them in the `Host` header